### PR TITLE
fix(raft): unblock orphan learner — clear suspend + allow promotion in roleSwitchIfNeed

### DIFF
--- a/pkg/raft/raft/node_step.go
+++ b/pkg/raft/raft/node_step.go
@@ -558,6 +558,21 @@ func (n *Node) committedIndexForFollow(leaderCommittedIndex uint64) uint64 {
 func (n *Node) roleSwitchIfNeed(e types.Event) {
 	// 没有需要切换的配置
 	if n.cfg.MigrateTo == 0 || n.cfg.MigrateFrom == 0 {
+		// 兜底：处理 orphan learner —— 在 Learners 列表中但前次迁移已完成
+		// （MigrateFrom/MigrateTo 已清零）。这种 learner 没有任何迁移标记可
+		// 触发晋升，会永远卡在 learner 角色。在这里检测它并在日志追上后
+		// 主动晋升为 follower。
+		if n.isLearner(e.From) {
+			syncInfo := n.replicaSync[e.From]
+			if syncInfo == nil || syncInfo.roleSwitching {
+				return
+			}
+			// 与正常 learner→follower 分支保持一致的日志差距判定
+			if e.Index+n.opts.LearnerToFollowerMinLogGap > n.queue.lastLogIndex {
+				syncInfo.roleSwitching = true
+				n.sendLearnerToFollowerReq(e.From)
+			}
+		}
 		return
 	}
 

--- a/pkg/raft/raft/node_step.go
+++ b/pkg/raft/raft/node_step.go
@@ -324,6 +324,7 @@ func (n *Node) stepLearner(e types.Event) error {
 		}
 	case types.NotifySync:
 		n.idleTick = 0
+		n.suspend = false // 解除挂起，允许后续 tickSync
 		n.sendSyncReq()
 		n.advance()
 	case types.SyncResp: // 同步返回

--- a/pkg/raft/raft/node_step.go
+++ b/pkg/raft/raft/node_step.go
@@ -562,13 +562,23 @@ func (n *Node) roleSwitchIfNeed(e types.Event) {
 		// （MigrateFrom/MigrateTo 已清零）。这种 learner 没有任何迁移标记可
 		// 触发晋升，会永远卡在 learner 角色。在这里检测它并在日志追上后
 		// 主动晋升为 follower。
-		if n.isLearner(e.From) {
+		//
+		// 注意：外层条件用的是 ||，所以当只清零了一半（例如 MigrateFrom!=0
+		// 而 MigrateTo==0）时也会进入这里。这种半清零状态属于迁移进行中，
+		// 不应触发 orphan 晋升，因此内层必须同时校验两者都为 0。
+		if n.isLearner(e.From) && n.cfg.MigrateTo == 0 && n.cfg.MigrateFrom == 0 {
 			syncInfo := n.replicaSync[e.From]
 			if syncInfo == nil || syncInfo.roleSwitching {
 				return
 			}
-			// 与正常 learner→follower 分支保持一致的日志差距判定
-			if e.Index+n.opts.LearnerToFollowerMinLogGap > n.queue.lastLogIndex {
+			// 与正常 learner→follower 分支保持一致：单副本集群必须完全追上
+			// 领导者的日志，否则用 gap-based 判定。
+			if len(n.cfg.Replicas) == 1 {
+				if e.Index > n.queue.lastLogIndex {
+					syncInfo.roleSwitching = true
+					n.sendLearnerToFollowerReq(e.From)
+				}
+			} else if e.Index+n.opts.LearnerToFollowerMinLogGap > n.queue.lastLogIndex {
 				syncInfo.roleSwitching = true
 				n.sendLearnerToFollowerReq(e.From)
 			}

--- a/pkg/raft/raft/node_step_test.go
+++ b/pkg/raft/raft/node_step_test.go
@@ -956,3 +956,76 @@ func TestLearner_NotifySync_ClearsSuspend(t *testing.T) {
 	_, ok := findEvent(events, types.SyncReq)
 	assert.True(t, ok, "learner should send SyncReq after NotifySync")
 }
+
+// TestRoleSwitchIfNeed_OrphanLearner_CaughtUp_Promotes verifies that a
+// learner stuck in cfg.Learners after a completed migration (MigrateFrom
+// and MigrateTo both zero) is still promoted to follower once its log
+// catches up to within LearnerToFollowerMinLogGap of the leader.
+func TestRoleSwitchIfNeed_OrphanLearner_CaughtUp_Promotes(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3})
+	makeLeader(n, 3)
+	n.cfg.Learners = []uint64{4}
+	n.cfg.MigrateTo = 0
+	n.cfg.MigrateFrom = 0
+	n.queue.lastLogIndex = 10
+	n.opts.LearnerToFollowerMinLogGap = 100
+	n.replicaSync[4] = &SyncInfo{}
+	// Orphan learner is close enough: Index + gap = 105 > lastLogIndex=10
+	n.roleSwitchIfNeed(types.Event{From: 4, Index: 5})
+	assert.True(t, n.replicaSync[4].roleSwitching, "orphan learner should be marked as switching")
+	events := collectEvents(n)
+	_, ok := findEvent(events, types.LearnerToFollowerReq)
+	assert.True(t, ok, "orphan learner should be promoted to follower")
+}
+
+// TestRoleSwitchIfNeed_OrphanLearner_NotCaughtUp_NoOp verifies that the
+// orphan-learner fallback does not fire prematurely while the learner is
+// still far behind the leader's log.
+func TestRoleSwitchIfNeed_OrphanLearner_NotCaughtUp_NoOp(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3})
+	makeLeader(n, 3)
+	n.cfg.Learners = []uint64{4}
+	n.cfg.MigrateTo = 0
+	n.cfg.MigrateFrom = 0
+	n.queue.lastLogIndex = 1000
+	n.opts.LearnerToFollowerMinLogGap = 100
+	n.replicaSync[4] = &SyncInfo{}
+	// Orphan learner is far behind: Index + gap = 105 <= lastLogIndex=1000
+	n.roleSwitchIfNeed(types.Event{From: 4, Index: 5})
+	assert.False(t, n.replicaSync[4].roleSwitching, "orphan learner should not switch when far behind")
+	events := collectEvents(n)
+	assert.Equal(t, 0, countEvents(events, types.LearnerToFollowerReq))
+}
+
+// TestRoleSwitchIfNeed_OrphanLearner_RoleSwitching_NoOp verifies that a
+// repeat call while a promotion is already in flight does not double-fire
+// the LearnerToFollowerReq.
+func TestRoleSwitchIfNeed_OrphanLearner_RoleSwitching_NoOp(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3})
+	makeLeader(n, 3)
+	n.cfg.Learners = []uint64{4}
+	n.cfg.MigrateTo = 0
+	n.cfg.MigrateFrom = 0
+	n.queue.lastLogIndex = 10
+	n.opts.LearnerToFollowerMinLogGap = 100
+	n.replicaSync[4] = &SyncInfo{roleSwitching: true}
+	n.roleSwitchIfNeed(types.Event{From: 4, Index: 5})
+	events := collectEvents(n)
+	assert.Equal(t, 0, countEvents(events, types.LearnerToFollowerReq))
+}
+
+// TestRoleSwitchIfNeed_NonLearner_NoMigration_NoOp guards against regressing
+// the original early-return guarantee: a non-learner replica with no active
+// migration must never trigger any role-switch traffic.
+func TestRoleSwitchIfNeed_NonLearner_NoMigration_NoOp(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3})
+	makeLeader(n, 3)
+	n.cfg.MigrateTo = 0
+	n.cfg.MigrateFrom = 0
+	n.replicaSync[2] = &SyncInfo{}
+	n.roleSwitchIfNeed(types.Event{From: 2, Index: 100})
+	events := collectEvents(n)
+	assert.Equal(t, 0, countEvents(events, types.LearnerToLeaderReq))
+	assert.Equal(t, 0, countEvents(events, types.LearnerToFollowerReq))
+	assert.Equal(t, 0, countEvents(events, types.FollowerToLeaderReq))
+}

--- a/pkg/raft/raft/node_step_test.go
+++ b/pkg/raft/raft/node_step_test.go
@@ -939,3 +939,20 @@ func TestRoleSwitchIfNeed_FollowerToLeader_CaughtUp(t *testing.T) {
 	_, ok := findEvent(events, types.FollowerToLeaderReq)
 	assert.True(t, ok)
 }
+
+// ==================== Orphan Learner Regression Tests ====================
+
+// TestLearner_NotifySync_ClearsSuspend verifies that stepLearner's NotifySync
+// branch clears n.suspend, mirroring stepFollower's behavior. Without this,
+// a learner that was suspended (e.g. after an empty sync round) would stay
+// suspended forever and never resume issuing sync requests via tickSync.
+func TestLearner_NotifySync_ClearsSuspend(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3})
+	makeLearner(n, 3, 2)
+	n.suspend = true
+	n.Step(types.Event{Type: types.NotifySync, Term: 3, From: 2})
+	assert.False(t, n.suspend, "learner should be unsuspended after NotifySync")
+	events := collectEvents(n)
+	_, ok := findEvent(events, types.SyncReq)
+	assert.True(t, ok, "learner should send SyncReq after NotifySync")
+}

--- a/pkg/raft/raft/raft.go
+++ b/pkg/raft/raft/raft.go
@@ -592,24 +592,39 @@ func (r *Raft) handleRoleChangeReq(e types.Event) {
 func (r *Raft) learnTo(learnerId uint64) (types.Config, error) {
 	cfg := r.node.Config().Clone()
 
-	if learnerId != cfg.MigrateTo {
+	// orphan learner: 前次迁移已完成（MigrateFrom/MigrateTo 都为 0），
+	// 但 learnerId 仍残留在 cfg.Learners 中。此时既无迁移源也无迁移目标，
+	// 不能走常规迁移路径，否则会被 learnerId != cfg.MigrateTo 误拒绝。
+	orphan := cfg.MigrateTo == 0 && cfg.MigrateFrom == 0 &&
+		wkutil.ArrayContainsUint64(cfg.Learners, learnerId)
+
+	if !orphan && learnerId != cfg.MigrateTo {
 		r.Warn("learnerId not equal migrateTo", zap.Uint64("learnerId", learnerId), zap.Uint64("migrateTo", cfg.MigrateTo))
 		return types.Config{}, errors.New("learnerId not equal migrateTo")
 	}
 
 	cfg.Learners = wkutil.RemoveUint64(cfg.Learners, learnerId)
 
-	if !wkutil.ArrayContainsUint64(cfg.Replicas, cfg.MigrateTo) {
-		cfg.Replicas = append(cfg.Replicas, cfg.MigrateTo)
+	if orphan {
+		// orphan: 把 learnerId 直接加入 Replicas，不切换 leader，不移除旧节点。
+		if !wkutil.ArrayContainsUint64(cfg.Replicas, learnerId) {
+			cfg.Replicas = append(cfg.Replicas, learnerId)
+		}
+	} else {
+		// 正常迁移路径
+		if !wkutil.ArrayContainsUint64(cfg.Replicas, cfg.MigrateTo) {
+			cfg.Replicas = append(cfg.Replicas, cfg.MigrateTo)
+		}
+
+		if cfg.MigrateFrom != cfg.MigrateTo {
+			cfg.Replicas = wkutil.RemoveUint64(cfg.Replicas, cfg.MigrateFrom)
+		}
+
+		if cfg.MigrateFrom == r.LeaderId() { // 学习者转领导
+			cfg.Leader = cfg.MigrateTo
+		}
 	}
 
-	if cfg.MigrateFrom != cfg.MigrateTo {
-		cfg.Replicas = wkutil.RemoveUint64(cfg.Replicas, cfg.MigrateFrom)
-	}
-
-	if cfg.MigrateFrom == r.LeaderId() { // 学习者转领导
-		cfg.Leader = cfg.MigrateTo
-	}
 	cfg.MigrateFrom = 0
 	cfg.MigrateTo = 0
 

--- a/pkg/raft/raft/raft_learnto_test.go
+++ b/pkg/raft/raft/raft_learnto_test.go
@@ -1,0 +1,206 @@
+package raft
+
+import (
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/types"
+	"github.com/WuKongIM/WuKongIM/pkg/wkutil"
+	"github.com/WuKongIM/WuKongIM/pkg/wklog"
+	"github.com/stretchr/testify/assert"
+)
+
+// newTestRaftWithNode wires a minimal *Raft around an existing *Node so we
+// can exercise unexported helpers like learnTo without standing up the full
+// Storage/Transport/loop machinery.
+func newTestRaftWithNode(n *Node) *Raft {
+	return &Raft{
+		node: n,
+		Log:  wklog.NewWKLog("test-raft"),
+	}
+}
+
+// TestLearnTo_OrphanLearner_Promotes verifies the orphan-learner path: when
+// MigrateFrom/MigrateTo are both zero but learnerId still sits in
+// cfg.Learners, learnTo should return a config that moves the node out of
+// Learners and into Replicas without touching Leader.
+func TestLearnTo_OrphanLearner_Promotes(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3})
+	makeLeader(n, 3)
+	n.cfg.Learners = []uint64{4}
+	n.cfg.MigrateTo = 0
+	n.cfg.MigrateFrom = 0
+	r := newTestRaftWithNode(n)
+
+	cfg, err := r.learnTo(4)
+	assert.NoError(t, err)
+	assert.False(t, wkutil.ArrayContainsUint64(cfg.Learners, 4), "learner should be removed from Learners")
+	assert.True(t, wkutil.ArrayContainsUint64(cfg.Replicas, 4), "learner should be added to Replicas")
+	assert.Equal(t, uint64(0), cfg.MigrateFrom)
+	assert.Equal(t, uint64(0), cfg.MigrateTo)
+	// orphan path must NOT mutate the leader: the original leader (node 1)
+	// is still in Replicas, so no leadership transfer happens.
+	assert.Equal(t, uint64(1), cfg.Leader)
+	// original replicas must be preserved.
+	assert.True(t, wkutil.ArrayContainsUint64(cfg.Replicas, 1))
+	assert.True(t, wkutil.ArrayContainsUint64(cfg.Replicas, 2))
+	assert.True(t, wkutil.ArrayContainsUint64(cfg.Replicas, 3))
+}
+
+// TestLearnTo_OrphanLearner_AlreadyInReplicas_NoDuplicate guards against the
+// orphan path accidentally re-appending an id that already sits in Replicas.
+func TestLearnTo_OrphanLearner_AlreadyInReplicas_NoDuplicate(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3, 4})
+	makeLeader(n, 3)
+	n.cfg.Learners = []uint64{4}
+	n.cfg.MigrateTo = 0
+	n.cfg.MigrateFrom = 0
+	r := newTestRaftWithNode(n)
+
+	cfg, err := r.learnTo(4)
+	assert.NoError(t, err)
+	count := 0
+	for _, id := range cfg.Replicas {
+		if id == 4 {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "Replicas should contain learnerId exactly once")
+}
+
+// TestLearnTo_OrphanLearner_NotInLearners_Rejected verifies that the orphan
+// path only fires when learnerId is actually present in cfg.Learners. A
+// random id that is neither in Learners nor matches MigrateTo must be
+// rejected, otherwise the orphan branch becomes an unrestricted "promote
+// anyone to follower" hole.
+func TestLearnTo_OrphanLearner_NotInLearners_Rejected(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3})
+	makeLeader(n, 3)
+	n.cfg.Learners = []uint64{4}
+	n.cfg.MigrateTo = 0
+	n.cfg.MigrateFrom = 0
+	r := newTestRaftWithNode(n)
+
+	// 5 is not in Learners and does not match MigrateTo.
+	_, err := r.learnTo(5)
+	assert.Error(t, err)
+}
+
+// TestLearnTo_NormalMigration_Unchanged guards against the orphan branch
+// regressing the existing migration path: when MigrateTo/MigrateFrom are
+// set, behavior must match the pre-fix implementation (learnerId promoted
+// into Replicas, MigrateFrom removed, fields cleared).
+func TestLearnTo_NormalMigration_Unchanged(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3})
+	makeLeader(n, 3)
+	n.cfg.Learners = []uint64{4}
+	n.cfg.MigrateFrom = 2
+	n.cfg.MigrateTo = 4
+	r := newTestRaftWithNode(n)
+
+	cfg, err := r.learnTo(4)
+	assert.NoError(t, err)
+	assert.False(t, wkutil.ArrayContainsUint64(cfg.Learners, 4))
+	assert.True(t, wkutil.ArrayContainsUint64(cfg.Replicas, 4))
+	assert.False(t, wkutil.ArrayContainsUint64(cfg.Replicas, 2), "MigrateFrom node should be removed from Replicas")
+	assert.Equal(t, uint64(0), cfg.MigrateFrom)
+	assert.Equal(t, uint64(0), cfg.MigrateTo)
+}
+
+// TestLearnTo_NormalMigration_LeaderHandoff verifies the learner→leader
+// path is preserved: when MigrateFrom is the current leader, the new Leader
+// in the returned config must become MigrateTo.
+func TestLearnTo_NormalMigration_LeaderHandoff(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3})
+	makeLeader(n, 3)
+	n.cfg.Learners = []uint64{4}
+	n.cfg.MigrateFrom = 1 // current leader
+	n.cfg.MigrateTo = 4
+	r := newTestRaftWithNode(n)
+
+	cfg, err := r.learnTo(4)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(4), cfg.Leader, "leader should hand off to MigrateTo")
+	assert.False(t, wkutil.ArrayContainsUint64(cfg.Replicas, 1), "old leader (MigrateFrom) should be removed from Replicas")
+	assert.True(t, wkutil.ArrayContainsUint64(cfg.Replicas, 4))
+}
+
+// TestLearnTo_NormalMigration_WrongLearnerId_Rejected ensures the
+// pre-existing guard still rejects a learnerId that does not match
+// MigrateTo when a migration is active.
+func TestLearnTo_NormalMigration_WrongLearnerId_Rejected(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3})
+	makeLeader(n, 3)
+	n.cfg.Learners = []uint64{4}
+	n.cfg.MigrateFrom = 2
+	n.cfg.MigrateTo = 4
+	r := newTestRaftWithNode(n)
+
+	// learnerId 5 != MigrateTo 4 and we are mid-migration, so reject.
+	_, err := r.learnTo(5)
+	assert.Error(t, err)
+}
+
+// ==================== roleSwitchIfNeed half-cleared regression ====================
+
+// TestRoleSwitchIfNeed_HalfClearedMigration_NoOrphanFire verifies P2-2:
+// when only one of MigrateFrom/MigrateTo is zero (the migration is still
+// in flight), the orphan fallback must NOT fire even if e.From happens to
+// be a learner. Only the fully cleared (both zero) state qualifies.
+func TestRoleSwitchIfNeed_HalfClearedMigration_NoOrphanFire(t *testing.T) {
+	cases := []struct {
+		name        string
+		migrateFrom uint64
+		migrateTo   uint64
+	}{
+		{"MigrateFrom set, MigrateTo zero", 2, 0},
+		{"MigrateFrom zero, MigrateTo set", 0, 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := newTestNode(1, []uint64{1, 2, 3})
+			makeLeader(n, 3)
+			n.cfg.Learners = []uint64{4}
+			n.cfg.MigrateFrom = tc.migrateFrom
+			n.cfg.MigrateTo = tc.migrateTo
+			n.queue.lastLogIndex = 10
+			n.opts.LearnerToFollowerMinLogGap = 100
+			n.replicaSync[4] = &SyncInfo{}
+
+			// e.From=4 is a learner and caught up; orphan would have fired.
+			n.roleSwitchIfNeed(types.Event{From: 4, Index: 5})
+
+			assert.False(t, n.replicaSync[4].roleSwitching, "half-cleared migration must not trigger orphan promotion")
+			events := collectEvents(n)
+			assert.Equal(t, 0, countEvents(events, types.LearnerToFollowerReq))
+		})
+	}
+}
+
+// TestRoleSwitchIfNeed_OrphanLearner_SingleReplica_StrictCatchUp verifies
+// P2-1: in a single-replica cluster, the orphan branch (like the normal
+// learner→follower branch) must require the learner to fully catch up
+// (e.Index > lastLogIndex) before promotion, not just be within the gap.
+func TestRoleSwitchIfNeed_OrphanLearner_SingleReplica_StrictCatchUp(t *testing.T) {
+	// gap-close but not strictly caught up → no promotion.
+	n := newTestNode(1, []uint64{1})
+	makeLeader(n, 3)
+	n.cfg.Learners = []uint64{4}
+	n.cfg.MigrateTo = 0
+	n.cfg.MigrateFrom = 0
+	n.queue.lastLogIndex = 10
+	n.opts.LearnerToFollowerMinLogGap = 100
+	n.replicaSync[4] = &SyncInfo{}
+
+	// Index=5, lastLogIndex=10 → gap path would fire, strict path must not.
+	n.roleSwitchIfNeed(types.Event{From: 4, Index: 5})
+	assert.False(t, n.replicaSync[4].roleSwitching, "single-replica orphan must require strict catch-up")
+	events := collectEvents(n)
+	assert.Equal(t, 0, countEvents(events, types.LearnerToFollowerReq))
+
+	// strictly caught up → promotion fires.
+	n.roleSwitchIfNeed(types.Event{From: 4, Index: 11})
+	assert.True(t, n.replicaSync[4].roleSwitching, "single-replica orphan should promote when fully caught up")
+	events = collectEvents(n)
+	_, ok := findEvent(events, types.LearnerToFollowerReq)
+	assert.True(t, ok)
+}

--- a/pkg/raft/raftgroup/handle.go
+++ b/pkg/raft/raftgroup/handle.go
@@ -344,24 +344,39 @@ func (rg *RaftGroup) handleRoleChangeReq(r IRaft, e types.Event) {
 func (rg *RaftGroup) learnTo(r IRaft, learnerId uint64) (types.Config, error) {
 	cfg := r.Config().Clone()
 
-	if learnerId != cfg.MigrateTo {
+	// orphan learner: 前次迁移已完成（MigrateFrom/MigrateTo 都为 0），
+	// 但 learnerId 仍残留在 cfg.Learners 中。此时既无迁移源也无迁移目标，
+	// 不能走常规迁移路径，否则会被 learnerId != cfg.MigrateTo 误拒绝。
+	orphan := cfg.MigrateTo == 0 && cfg.MigrateFrom == 0 &&
+		wkutil.ArrayContainsUint64(cfg.Learners, learnerId)
+
+	if !orphan && learnerId != cfg.MigrateTo {
 		rg.Warn("learnerId not equal migrateTo", zap.Uint64("learnerId", learnerId), zap.Uint64("migrateTo", cfg.MigrateTo))
 		return types.Config{}, errors.New("learnerId not equal migrateTo")
 	}
 
 	cfg.Learners = wkutil.RemoveUint64(cfg.Learners, learnerId)
 
-	if !wkutil.ArrayContainsUint64(cfg.Replicas, cfg.MigrateTo) {
-		cfg.Replicas = append(cfg.Replicas, cfg.MigrateTo)
+	if orphan {
+		// orphan: 把 learnerId 直接加入 Replicas，不切换 leader，不移除旧节点。
+		if !wkutil.ArrayContainsUint64(cfg.Replicas, learnerId) {
+			cfg.Replicas = append(cfg.Replicas, learnerId)
+		}
+	} else {
+		// 正常迁移路径
+		if !wkutil.ArrayContainsUint64(cfg.Replicas, cfg.MigrateTo) {
+			cfg.Replicas = append(cfg.Replicas, cfg.MigrateTo)
+		}
+
+		if cfg.MigrateFrom != cfg.MigrateTo {
+			cfg.Replicas = wkutil.RemoveUint64(cfg.Replicas, cfg.MigrateFrom)
+		}
+
+		if cfg.MigrateFrom == r.LeaderId() { // 学习者转领导
+			cfg.Leader = cfg.MigrateTo
+		}
 	}
 
-	if cfg.MigrateFrom != cfg.MigrateTo {
-		cfg.Replicas = wkutil.RemoveUint64(cfg.Replicas, cfg.MigrateFrom)
-	}
-
-	if cfg.MigrateFrom == r.LeaderId() { // 学习者转领导
-		cfg.Leader = cfg.MigrateTo
-	}
 	cfg.MigrateFrom = 0
 	cfg.MigrateTo = 0
 


### PR DESCRIPTION
Fixes https://github.com/Mininglamp-OSS/WuKongIM/issues/1

Two raft-layer bugs in `pkg/raft/raft/node_step.go` together leave an orphan learner — a node still in `cfg.Learners` after a learner→follower migration completed and cleared `MigrateFrom`/`MigrateTo` — permanently stuck. Either bug alone is enough to wedge it; both together make recovery impossible without manual intervention.

## Bug 1 — `stepLearner` `NotifySync` never clears `n.suspend`

`stepLearner`'s `NotifySync` branch was missing the `n.suspend = false` line that `stepFollower`'s symmetric branch already has. Once an empty sync round flips `n.suspend = true` (via `SpeedSuspend` from `stepLeader`'s `AutoSuspend` path), the learner ignores every subsequent `tickSync` and stops emitting `SyncReq`. New logs on the leader never reach it.

Fix: mirror `stepFollower` and clear `n.suspend` on `NotifySync` so the learner resumes syncing.

## Bug 2 — `roleSwitchIfNeed` early-return blocks orphan-learner promotion

`roleSwitchIfNeed` returns immediately when either `MigrateFrom` or `MigrateTo` is zero. After a learner→follower migration completes those fields are reset to zero by design — and from that point on, even if a node remains in `cfg.Learners` (orphan learner) and its log fully catches up, there is no path in the function that can emit `LearnerToFollowerReq` for it.

Fix: keep the original early-return for non-learner replicas, but add a fallback inside it for nodes that are in `cfg.Learners` with `MigrateFrom == 0 && MigrateTo == 0`. Reuse the same `LearnerToFollowerMinLogGap` threshold and `roleSwitching` guard the migration-active learner→follower path uses, and emit `LearnerToFollowerReq` once the orphan catches up.

## Tests

Added in `pkg/raft/raft/node_step_test.go`:

- `TestLearner_NotifySync_ClearsSuspend` — learner with `suspend = true` is unsuspended after `NotifySync` and emits `SyncReq`.
- `TestRoleSwitchIfNeed_OrphanLearner_CaughtUp_Promotes` — orphan learner whose log is within `LearnerToFollowerMinLogGap` of the leader triggers `LearnerToFollowerReq` and is marked `roleSwitching`.
- `TestRoleSwitchIfNeed_OrphanLearner_NotCaughtUp_NoOp` — orphan learner far behind the leader does **not** trigger promotion.
- `TestRoleSwitchIfNeed_OrphanLearner_RoleSwitching_NoOp` — orphan learner with a promotion already in flight is not re-fired.
- `TestRoleSwitchIfNeed_NonLearner_NoMigration_NoOp` — regression guard: non-learner replica with no active migration still emits no role-switch traffic.

All new tests pass alongside the existing `pkg/raft/raft` suite:

```
go test ./pkg/raft/raft/
ok  	github.com/WuKongIM/WuKongIM/pkg/raft/raft	4.648s
```

## Commits

- `fix(raft): clear suspend on NotifySync in stepLearner`
- `fix(raft): allow orphan learner promotion in roleSwitchIfNeed`
