### PR TITLE
ci: add Docker lint workflow (hadolint + shellcheck)

### DIFF
--- a/.github/workflows/docker-lint.yml
+++ b/.github/workflows/docker-lint.yml
@@ -1,0 +1,21 @@
+name: Docker Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile*'
+      - 'docker/**'
+      - '.hadolint.yaml'
+      - '.github/workflows/docker-lint.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile*'
+      - 'docker/**'
+      - '.hadolint.yaml'
+      - '.github/workflows/docker-lint.yml'
+
+jobs:
+  docker-lint:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-docker-lint.yml@main

--- a/.github/workflows/docker-lint.yml
+++ b/.github/workflows/docker-lint.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'Dockerfile*'
+      - 'web/Dockerfile*'
       - 'docker/**'
       - '.hadolint.yaml'
       - '.github/workflows/docker-lint.yml'
@@ -12,6 +13,7 @@ on:
     branches: [main]
     paths:
       - 'Dockerfile*'
+      - 'web/Dockerfile*'
       - 'docker/**'
       - '.hadolint.yaml'
       - '.github/workflows/docker-lint.yml'
@@ -19,3 +21,5 @@ on:
 jobs:
   docker-lint:
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-docker-lint.yml@main
+    with:
+      dockerfiles: 'Dockerfile web/Dockerfile'


### PR DESCRIPTION
## What

Add `docker-lint.yml` caller workflow that invokes the organization's
`reusable-docker-lint.yml` to lint Dockerfiles (hadolint) and shell
scripts in `docker/` (shellcheck).

## How it works

- **hadolint**: auto-discovers `Dockerfile*` at repo root. Skips gracefully
  if none found.
- **shellcheck**: scans `./docker/` for `.sh` files. Skips gracefully if
  directory doesn't exist or has no scripts.
- Only triggers on changes to Docker-related files (path filter).

## Dependency

Requires Mininglamp-OSS/.github#61 to be merged first (the reusable
workflow definition).

Ref: Mininglamp-OSS workflow optimization T11.
