### PR TITLE
fix: enable edge-triggered IO on host gnet servers (stop EPOLLOUT busy-spin)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -321,3 +321,5 @@ replace github.com/hashicorp/consul => github.com/hashicorp/consul v1.14.5
 
 // replace github.com/WuKongIM/WuKongIMGoSDK => ../../WuKongIMGoSDK
 // replace github.com/WuKongIM/WuKongIMGoProto => ../../WuKongIMGoProto
+
+replace github.com/WuKongIM/wkrpc => github.com/Mininglamp-OSS/wkrpc v0.0.0-20260613104221-1f5f7474c595

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/Microsoft/go-winio v0.4.3/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyv
 github.com/Microsoft/go-winio v0.4.9/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/Mininglamp-OSS/wkrpc v0.0.0-20260613104221-1f5f7474c595 h1:dXSs8pB29c9IW3qGGlPVJ+W/N6tzLZ3ykk21ILdAqE4=
+github.com/Mininglamp-OSS/wkrpc v0.0.0-20260613104221-1f5f7474c595/go.mod h1:JXp1IM0XGJxq987jDEP/63dmb8/pEyXw12es04gUjuI=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.0.1/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
@@ -276,8 +278,6 @@ github.com/WuKongIM/crypto v0.0.0-20240416072338-b872b70b395f h1:erzPrCjuS7yvfpM
 github.com/WuKongIM/crypto v0.0.0-20240416072338-b872b70b395f/go.mod h1:gS8ErzMrBY+zJfxwFFzUzR9S2jFo/FTyEVr4pedbfbA=
 github.com/WuKongIM/wklog v0.0.0-20250123094253-32484fb54d05 h1:z6Zu0VFnXA/+IcNAI/G0QgvIZZlU4aF6pf/fPP780hY=
 github.com/WuKongIM/wklog v0.0.0-20250123094253-32484fb54d05/go.mod h1:/juNjLcqcoW/NkNi4rxnhDvDAUo76w3qIZ4dgLkZvH0=
-github.com/WuKongIM/wkrpc v0.0.0-20250312122115-5e44de72d2c8 h1:oybJMy0RJ5DGYiE26hT0Ud2uKUUXP50LCEXonhwrgik=
-github.com/WuKongIM/wkrpc v0.0.0-20250312122115-5e44de72d2c8/go.mod h1:JXp1IM0XGJxq987jDEP/63dmb8/pEyXw12es04gUjuI=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/aerospike/aerospike-client-go v1.27.0/go.mod h1:zj8LBEnWBDOVEIJt8LvaRvDG5ARAoa5dBeHaB472NRc=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=

--- a/pkg/wkserver/server.go
+++ b/pkg/wkserver/server.go
@@ -105,7 +105,7 @@ func (s *Server) Start() error {
 	})
 
 	go func() {
-		err := gnet.Run(s, s.opts.Addr, gnet.WithTicker(true), gnet.WithReuseAddr(true))
+		err := gnet.Run(s, s.opts.Addr, gnet.WithTicker(true), gnet.WithReuseAddr(true), gnet.WithEdgeTriggeredIO(true))
 		if err != nil {
 			s.Panic("gnet run error", zap.Error(err), zap.String("addr", s.opts.Addr))
 		}


### PR DESCRIPTION
## What

Stop the host from busy-spinning a CPU core on EPOLLOUT under downstream backpressure, by enabling edge-triggered I/O on the gnet servers.

### Changes (independent, individually revertable)
1. **`pkg/wkserver/server.go`** — add `gnet.WithEdgeTriggeredIO(true)` to the inter-node transport server's `gnet.Run(...)`. Same level-triggered EPOLLOUT spin as the RPC server: a write to a peer hits `EAGAIN`, `EPOLLOUT` stays armed, and the event loop returns immediately every iteration until the buffer drains.
2. **`go.mod` / `go.sum`** — `replace github.com/WuKongIM/wkrpc => github.com/Mininglamp-OSS/wkrpc@<fork>`, pinned to the fork commit that enables edge-triggered I/O on the RPC server (the path that was actually burning the core in production).

## Verification
```
go build ./...                                   # exit 0
grep -n "Mininglamp-OSS/wkrpc" go.mod go.sum     # replace + both sum lines present
go list -m github.com/panjf2000/gnet/v2          # v2.7.1 (unchanged)
```
- gnet stays at `v2.7.1`; the `module` line is unchanged; `go.sum` only swaps the wkrpc entry.

## Base
⚠️ This PR targets the production baseline line, **not** `main` (main has moved on to the v3 rewrite). Branched from tag `v2.2.5-20260422-fix1` (commit `02cf8cd19877e307a31cc13412155579a36bf0a4`).

## Depends on
Mininglamp-OSS/wkrpc#1 — the fork commit referenced by the `go.mod` replace. The pinned commit is already pushed, so this builds today; merge the fork PR first to keep the fork's default branch consistent.
