### PR TITLE
revert: ET edge-triggered IO (放弃 ET 方案, 转 mysql ETL 路线)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -321,5 +321,3 @@ replace github.com/hashicorp/consul => github.com/hashicorp/consul v1.14.5
 
 // replace github.com/WuKongIM/WuKongIMGoSDK => ../../WuKongIMGoSDK
 // replace github.com/WuKongIM/WuKongIMGoProto => ../../WuKongIMGoProto
-
-replace github.com/WuKongIM/wkrpc => github.com/Mininglamp-OSS/wkrpc v0.0.0-20260613104221-1f5f7474c595

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,6 @@ github.com/Microsoft/go-winio v0.4.3/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyv
 github.com/Microsoft/go-winio v0.4.9/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Mininglamp-OSS/wkrpc v0.0.0-20260613104221-1f5f7474c595 h1:dXSs8pB29c9IW3qGGlPVJ+W/N6tzLZ3ykk21ILdAqE4=
-github.com/Mininglamp-OSS/wkrpc v0.0.0-20260613104221-1f5f7474c595/go.mod h1:JXp1IM0XGJxq987jDEP/63dmb8/pEyXw12es04gUjuI=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.0.1/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
@@ -278,6 +276,8 @@ github.com/WuKongIM/crypto v0.0.0-20240416072338-b872b70b395f h1:erzPrCjuS7yvfpM
 github.com/WuKongIM/crypto v0.0.0-20240416072338-b872b70b395f/go.mod h1:gS8ErzMrBY+zJfxwFFzUzR9S2jFo/FTyEVr4pedbfbA=
 github.com/WuKongIM/wklog v0.0.0-20250123094253-32484fb54d05 h1:z6Zu0VFnXA/+IcNAI/G0QgvIZZlU4aF6pf/fPP780hY=
 github.com/WuKongIM/wklog v0.0.0-20250123094253-32484fb54d05/go.mod h1:/juNjLcqcoW/NkNi4rxnhDvDAUo76w3qIZ4dgLkZvH0=
+github.com/WuKongIM/wkrpc v0.0.0-20250312122115-5e44de72d2c8 h1:oybJMy0RJ5DGYiE26hT0Ud2uKUUXP50LCEXonhwrgik=
+github.com/WuKongIM/wkrpc v0.0.0-20250312122115-5e44de72d2c8/go.mod h1:JXp1IM0XGJxq987jDEP/63dmb8/pEyXw12es04gUjuI=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/aerospike/aerospike-client-go v1.27.0/go.mod h1:zj8LBEnWBDOVEIJt8LvaRvDG5ARAoa5dBeHaB472NRc=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=

--- a/pkg/wkserver/server.go
+++ b/pkg/wkserver/server.go
@@ -105,7 +105,7 @@ func (s *Server) Start() error {
 	})
 
 	go func() {
-		err := gnet.Run(s, s.opts.Addr, gnet.WithTicker(true), gnet.WithReuseAddr(true), gnet.WithEdgeTriggeredIO(true))
+		err := gnet.Run(s, s.opts.Addr, gnet.WithTicker(true), gnet.WithReuseAddr(true))
 		if err != nil {
 			s.Panic("gnet run error", zap.Error(err), zap.String("addr", s.opts.Addr))
 		}


### PR DESCRIPTION
## 背景
撤销 #18「fix: enable edge-triggered IO on host gnet servers」(已 MERGED, merge commit f0acef6)。

## 原因
ET(edge-triggered IO)方案经线上 et3 镜像验收实证失败(gnet 事件循环 CPU 自旋未解决)。Yu 决策:放弃对 wukongim 进程内插件的底层代码改动,改走 mysql ETL 路线。ET 相关代码彻底回退。

## 改动(git revert -m 1 f0acef6,3 文件)
- `pkg/wkserver/server.go`: 去掉 `gnet.WithEdgeTriggeredIO(true)`(同时回退 #18 带入的 a4b496c6 inter-node ET 与 host ET)
- `go.mod`: 删除 `replace github.com/WuKongIM/wkrpc => github.com/Mininglamp-OSS/wkrpc ...`
- `go.sum`: 还原回上游 `github.com/WuKongIM/wkrpc v0.0.0-20250312122115-5e44de72d2c8`

## 验证
- `go mod download github.com/WuKongIM/wkrpc` 成功,无悬空 fork replace。
- 合并后 octo-im 不再引用 Mininglamp-OSS/wkrpc fork,fork 可安全删除。

## 注意
仅 GitHub 仓库操作,不碰 k8s/生产(线上 develop 跑 octo-im:v2.2.5-fix1,与此 PR 链路无关)。