### PR TITLE
fix: skip LastAppendTime calculation when lastAppendTime is zero

### DIFF
--- a/pkg/cluster/cluster/api_node.go
+++ b/pkg/cluster/cluster/api_node.go
@@ -268,7 +268,9 @@ func (s *Server) nodeChannelsGet(c *wkhttp.Context) {
 					channelClusterConfigResp.ActiveFormat = "未运行"
 				}
 				channelClusterConfigResp.LastMessageSeq = statusResp.LastMsgSeq
-				channelClusterConfigResp.LastAppendTime = myUptime(time.Since(time.Unix(int64(statusResp.LastMsgTime/1e9), 0)))
+				if statusResp.LastMsgTime > 0 {
+					channelClusterConfigResp.LastAppendTime = myUptime(time.Since(time.Unix(int64(statusResp.LastMsgTime/1e9), 0)))
+				}
 				break
 			}
 		}


### PR DESCRIPTION
## Problem

When `lastAppendTime` is 0 (epoch), the duration calculation produces a huge value (years since 1970), which is displayed incorrectly to users in the channel cluster config list API.

## Root Cause

In `pkg/cluster/cluster/api_node.go` line 271, the `LastAppendTime` field was set unconditionally:

```go
// Before (no guard):
channelClusterConfigResp.LastAppendTime = myUptime(time.Since(time.Unix(int64(statusResp.LastMsgTime/1e9), 0)))
```

When `statusResp.LastMsgTime == 0`, this calculates the duration since Unix epoch (1970), resulting in a display like "56 years ago" for channels that never received a message.

## Fix

Added a `> 0` guard before computing `time.Since()`, consistent with the existing guard at line 208 in the same file:

```go
// After (with guard):
if statusResp.LastMsgTime > 0 {
    channelClusterConfigResp.LastAppendTime = myUptime(time.Since(time.Unix(int64(statusResp.LastMsgTime/1e9), 0)))
}
```

When `lastMsgTime` is zero, `LastAppendTime` is left as empty string (zero value), which is the correct behavior for channels that haven't received any messages.

## Branch Info

This fix is based on tag `v2.2.5-20260422` where the affected code path exists.

Fixes #24