### PR TITLE
fix: memory leak in RaftGroup on propose-forward timeout (progress slice + fowardProposeWait map)

### DIFF
--- a/pkg/raft/raftgroup/raftgroup_propose.go
+++ b/pkg/raft/raftgroup/raftgroup_propose.go
@@ -128,6 +128,9 @@ func (rg *RaftGroup) ProposeBatchUntilAppliedTimeout(ctx context.Context, raftKe
 		case <-ctx.Done():
 			rg.Error("propose batch until applied timeout", zap.String("raftKey", raftKey), zap.Uint64("leader", raft.LeaderId()), zap.Any("resps", resps), zap.String("progress", applyProcess.String()))
 			// rg.wait.put(applyProcess) // 这里不需要put，因为如果这里put了，那么在waitApply中wait会出现close of nil channel
+			// Mark done so clean() removes it from progresses slice on next didApply call,
+			// preventing unbounded growth of the progresses slice on timeout.
+			applyProcess.done = true
 			return nil, ctx.Err()
 		case <-rg.stopper.ShouldStop():
 			rg.Error("propose batch until applied stopped", zap.String("raftKey", raftKey), zap.Any("resps", resps), zap.String("progress", applyProcess.String()))
@@ -224,6 +227,8 @@ func (rg *RaftGroup) fowardPropose(ctx context.Context, raft IRaft, reqs types.P
 		}
 		return result.(types.ProposeRespSet), nil
 	case <-ctx.Done():
+		// Trigger removes the key from fowardProposeWait map to prevent a map leak.
+		rg.fowardProposeWait.Trigger(key, ctx.Err())
 		rg.Error("foward propose timeout", zap.String("raftKey", raft.Key()))
 		return nil, ctx.Err()
 	case <-rg.stopper.ShouldStop():


### PR DESCRIPTION
## Summary

Fixes two memory leaks in `pkg/raft/raftgroup/raftgroup_propose.go` that cause unbounded memory growth on follower nodes when propose-forward to leader times out.

Fixes: https://github.com/Mininglamp-OSS/octo-im/issues/28

## Root Cause

### Bug 1 — `progresses` slice grows unboundedly on apply-wait timeout

**File:** `pkg/raft/raftgroup/raftgroup_propose.go` (in `ProposeBatchUntilAppliedTimeout`)

On the `ctx.Done()` branch, `applyProcess.done` was never set to `true`, so `clean()` never removed the entry from the `progresses` slice. Every timed-out propose on a follower node permanently accumulated an orphaned `*progress` in the slice.

**Fix:**
```go
case <-ctx.Done():
    applyProcess.done = true   // ← added
    return nil, ctx.Err()
```

### Bug 2 — `fowardProposeWait` map entry never removed on timeout

**File:** `pkg/raft/raftgroup/raftgroup_propose.go` (in `fowardPropose`)

`Register(key)` adds an entry to the wait map. On normal completion `Trigger` is called to remove it, but on the `ctx.Done()` branch `Trigger` was never called, leaving a dangling map entry on every timeout.

**Fix:**
```go
case <-ctx.Done():
    rg.fowardProposeWait.Trigger(key, ctx.Err())   // ← added
    rg.Error("foward propose timeout", ...)
    return nil, ctx.Err()
```

## Impact

Without this fix, a follower node under propose-forward-timeout load will accumulate unbounded memory. Observed behaviour: OOMKilled after ~3 days, RSS ~3,889 MiB on a TKE Serverless StatefulSet (3 replicas, version v2.2.5-20260422-fix1).

## Files Changed

- `pkg/raft/raftgroup/raftgroup_propose.go` — two one-liner fixes on timeout paths
