### PR TITLE
fix: memory leak in RaftGroup on propose-forward timeout (lock-safe markDone, no data race)

### DIFF
--- a/pkg/raft/raftgroup/raftgroup_propose.go
+++ b/pkg/raft/raftgroup/raftgroup_propose.go
@@ -128,6 +128,9 @@ func (rg *RaftGroup) ProposeBatchUntilAppliedTimeout(ctx context.Context, raftKe
 		case <-ctx.Done():
 			rg.Error("propose batch until applied timeout", zap.String("raftKey", raftKey), zap.Uint64("leader", raft.LeaderId()), zap.Any("resps", resps), zap.String("progress", applyProcess.String()))
 			// rg.wait.put(applyProcess) // 这里不需要put，因为如果这里put了，那么在waitApply中wait会出现close of nil channel
+			// Mark done under the bucket lock so clean() removes it from the progresses
+			// slice immediately, preventing unbounded growth on repeated timeouts.
+			rg.wait.markDone(applyProcess)
 			return nil, ctx.Err()
 		case <-rg.stopper.ShouldStop():
 			rg.Error("propose batch until applied stopped", zap.String("raftKey", raftKey), zap.Any("resps", resps), zap.String("progress", applyProcess.String()))
@@ -224,6 +227,8 @@ func (rg *RaftGroup) fowardPropose(ctx context.Context, raft IRaft, reqs types.P
 		}
 		return result.(types.ProposeRespSet), nil
 	case <-ctx.Done():
+		// Trigger removes the key from fowardProposeWait map to prevent a map leak.
+		rg.fowardProposeWait.Trigger(key, ctx.Err())
 		rg.Error("foward propose timeout", zap.String("raftKey", raft.Key()))
 		return nil, ctx.Err()
 	case <-rg.stopper.ShouldStop():

--- a/pkg/raft/raftgroup/wait.go
+++ b/pkg/raft/raftgroup/wait.go
@@ -38,6 +38,13 @@ func (m *wait) put(progress *progress) {
 	m.buckets[m.bucketIndex(progress.key)].put(progress)
 }
 
+// markDone marks a progress entry as done under the bucket lock, then immediately
+// removes it from the progresses slice via clean(). Use this on timeout paths
+// where put() cannot be called (putting would close the channel prematurely).
+func (m *wait) markDone(p *progress) {
+	m.buckets[m.bucketIndex(p.key)].markDone(p)
+}
+
 func fnv32(key string) uint32 {
 	const (
 		offset32 = 2166136261
@@ -141,6 +148,16 @@ func (m *waitBucket) didApply(key string, maxLogIndex uint64) {
 		}
 	}
 	// 清理
+	m.clean()
+}
+
+// markDone sets p.done = true under the bucket lock and immediately cleans the
+// progresses slice. This is the lock-safe counterpart to the timeout path in
+// ProposeBatchUntilAppliedTimeout where put() must not be called.
+func (m *waitBucket) markDone(p *progress) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p.done = true
 	m.clean()
 }
 


### PR DESCRIPTION
## Summary

Fixes two memory leaks in `pkg/raft/raftgroup/raftgroup_propose.go` that cause unbounded memory growth on follower nodes when propose-forward to leader times out.

Fixes: https://github.com/Mininglamp-OSS/octo-im/issues/28

Supersedes: #29 (closed — had a data race in Bug 1 fix, addressed here)

## Root Cause

### Bug 1 — `progresses` slice grows unboundedly on apply-wait timeout

**File:** `pkg/raft/raftgroup/raftgroup_propose.go` (in `ProposeBatchUntilAppliedTimeout`)

On the `ctx.Done()` branch, `applyProcess.done` was never set to `true`, so `clean()` never removed the entry from the `progresses` slice. Every timed-out propose on a follower node permanently accumulated an orphaned `*progress` in the slice.

**Previous fix in #29 had a data race:** `applyProcess.done = true` was written without holding the bucket lock, racing with `didApply` (which reads `progress.done` and calls `clean()` under `waitBucket.mu`).

**Correct fix:** Add a `markDone` helper on `waitBucket` (and `wait`) that sets `done = true` **under `m.mu.Lock()`** and immediately calls `clean()` to reclaim the entry proactively, rather than waiting for the next `didApply`:

```go
// wait.go — new locked helper
func (m *waitBucket) markDone(p *progress) {
    m.mu.Lock()
    defer m.mu.Unlock()
    p.done = true
    m.clean()
}

// raftgroup_propose.go — timeout path
case <-ctx.Done():
    rg.wait.markDone(applyProcess)  // lock-safe; reclaims entry immediately
    return nil, ctx.Err()
```

### Bug 2 — `fowardProposeWait` map entry never removed on timeout

**File:** `pkg/raft/raftgroup/raftgroup_propose.go` (in `fowardPropose`)

`Register(key)` adds an entry to the wait map. On normal completion `Trigger` is called to remove it, but on the `ctx.Done()` branch `Trigger` was never called, leaving a dangling map entry on every timeout.

**Fix** (same as #29, no change — this one was already correct):
```go
case <-ctx.Done():
    rg.fowardProposeWait.Trigger(key, ctx.Err())
    rg.Error("foward propose timeout", ...)
    return nil, ctx.Err()
```

## Changes

- `pkg/raft/raftgroup/wait.go` — add `markDone` on `waitBucket` and `wait`
- `pkg/raft/raftgroup/raftgroup_propose.go` — use `rg.wait.markDone(applyProcess)` on timeout path; keep `Trigger` fix for fowardProposeWait

## Impact

Without this fix, a follower node under propose-forward-timeout load will accumulate unbounded memory. Observed behaviour: OOMKilled after ~3 days, RSS ~3,889 MiB on a TKE Serverless StatefulSet (3 replicas, version v2.2.5-20260422-fix1).

## Verification

- `go build ./pkg/raft/raftgroup/...` — clean
- `go test -race ./pkg/raft/raftgroup/...` — `markDone` is not involved in any race report; pre-existing races in `raft/node.go:LeaderId()` (test-only accessor) are unrelated to this fix
