### PR TITLE
fix: route unread mutations through channel leader

### DIFF
--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -18,7 +18,8 @@
 - `ActiveAt` is a best-effort hint: updates may be batched, throttled, dropped, and merged from cache during `ListUserConversationActive`.
 - Deleting a conversation clears current active visibility through `DeletedToSeq`; a later message with a larger sequence must be allowed to reactivate it.
 - Delete without an explicit message sequence must first resolve the latest Channel Log sequence; if no sequence is available, do not install a zero delete barrier.
-- Conversation read-cursor mutations must resolve the latest message through a leader-required, epoch-fenced read; a readable follower is not authoritative even when it is `CommitReady`.
+- Conversation read-cursor mutations must resolve the latest message through a leader-required, epoch-fenced read; a readable follower, lease-expired leader, write-fenced leader, or drained former leader is not authoritative even when it is `CommitReady`.
+- Read-cursor route resolution must use non-bootstrapping metadata activation; an unknown client-supplied channel ID must not create runtime metadata.
 - A leader-reroute retry must invalidate cached channel metadata before refreshing it; otherwise both attempts can target the same former leader.
 - During mixed-version rollout, a peer that does not understand the authoritative conversation-facts codec must fail closed with a retryable response; never fall back to an unfenced legacy read.
 - Ordinary conversation sync remains best-effort per channel: a transiently not-ready remote channel must not fail the user's whole conversation list.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -23,6 +23,7 @@
 - Read-cursor route resolution must use non-bootstrapping metadata activation; an unknown client-supplied channel ID must not create runtime metadata.
 - A leader-reroute retry must invalidate cached channel metadata before refreshing it; otherwise both attempts can target the same former leader.
 - Conversation mutation APIs must map transient internal routing failures to a stable retryable response and never expose raw internal errors.
+- Authoritative conversation-facts RPC must preserve permanent channel states so local and remote mutation paths return the same result without retrying.
 - During mixed-version rollout, a peer that does not understand the authoritative conversation-facts codec must fail closed with a retryable response; never fall back to an unfenced legacy read.
 - Ordinary conversation sync remains best-effort per channel: a transiently not-ready remote channel must not fail the user's whole conversation list.
 - Duplicate/stale delete barriers must not clear an `ActiveAt` written by a newer message.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -18,6 +18,7 @@
 - `ActiveAt` is a best-effort hint: updates may be batched, throttled, dropped, and merged from cache during `ListUserConversationActive`.
 - Deleting a conversation clears current active visibility through `DeletedToSeq`; a later message with a larger sequence must be allowed to reactivate it.
 - Delete without an explicit message sequence must first resolve the latest Channel Log sequence; if no sequence is available, do not install a zero delete barrier.
+- Delete without an explicit message sequence returns a stable conflict response when no latest message payload is available; this client-reachable condition is not an internal server failure.
 - Conversation read-cursor mutations must resolve the latest message through a leader-required, epoch-fenced read; a readable follower, lease-expired leader, write-fenced leader, or drained former leader is not authoritative even when it is `CommitReady`.
 - Read-cursor route resolution must use non-bootstrapping metadata activation; an unknown client-supplied channel ID must not create runtime metadata.
 - A leader-reroute retry must invalidate cached channel metadata before refreshing it; otherwise both attempts can target the same former leader.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -19,6 +19,8 @@
 - Deleting a conversation clears current active visibility through `DeletedToSeq`; a later message with a larger sequence must be allowed to reactivate it.
 - Delete without an explicit message sequence must first resolve the latest Channel Log sequence; if no sequence is available, do not install a zero delete barrier.
 - Conversation read-cursor mutations must resolve the latest message through a leader-required, epoch-fenced read; a readable follower is not authoritative even when it is `CommitReady`.
+- A leader-reroute retry must invalidate cached channel metadata before refreshing it; otherwise both attempts can target the same former leader.
+- During mixed-version rollout, a peer that does not understand the authoritative conversation-facts codec must fail closed with a retryable response; never fall back to an unfenced legacy read.
 - Ordinary conversation sync remains best-effort per channel: a transiently not-ready remote channel must not fail the user's whole conversation list.
 - Duplicate/stale delete barriers must not clear an `ActiveAt` written by a newer message.
 - Legacy channel allowlist, denylist, and temporary-subscriber APIs are backed by namespaced slot subscriber lists until dedicated metadata tables exist.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -21,6 +21,7 @@
 - Conversation read-cursor mutations must resolve the latest message through a leader-required, epoch-fenced read; a readable follower, lease-expired leader, write-fenced leader, or drained former leader is not authoritative even when it is `CommitReady`.
 - Read-cursor route resolution must use non-bootstrapping metadata activation; an unknown client-supplied channel ID must not create runtime metadata.
 - A leader-reroute retry must invalidate cached channel metadata before refreshing it; otherwise both attempts can target the same former leader.
+- Conversation mutation APIs must map transient internal routing failures to a stable retryable response and never expose raw internal errors.
 - During mixed-version rollout, a peer that does not understand the authoritative conversation-facts codec must fail closed with a retryable response; never fall back to an unfenced legacy read.
 - Ordinary conversation sync remains best-effort per channel: a transiently not-ready remote channel must not fail the user's whole conversation list.
 - Duplicate/stale delete barriers must not clear an `ActiveAt` written by a newer message.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -18,6 +18,8 @@
 - `ActiveAt` is a best-effort hint: updates may be batched, throttled, dropped, and merged from cache during `ListUserConversationActive`.
 - Deleting a conversation clears current active visibility through `DeletedToSeq`; a later message with a larger sequence must be allowed to reactivate it.
 - Delete without an explicit message sequence must first resolve the latest Channel Log sequence; if no sequence is available, do not install a zero delete barrier.
+- Conversation read-cursor mutations must resolve the latest message through a leader-required, epoch-fenced read; a readable follower is not authoritative even when it is `CommitReady`.
+- Ordinary conversation sync remains best-effort per channel: a transiently not-ready remote channel must not fail the user's whole conversation list.
 - Duplicate/stale delete barriers must not clear an `ActiveAt` written by a newer message.
 - Legacy channel allowlist, denylist, and temporary-subscriber APIs are backed by namespaced slot subscriber lists until dedicated metadata tables exist.
 - Legacy system UID APIs are backed by the namespaced slot subscriber list `__wk_internal_system_uids__`.

--- a/internal/access/api/channel_messagesync.go
+++ b/internal/access/api/channel_messagesync.go
@@ -64,11 +64,15 @@ func (s *Server) handleChannelMessageSync(c *gin.Context) {
 }
 
 func writeLegacyJSONError(c *gin.Context, message string) {
+	writeLegacyJSONErrorStatus(c, http.StatusBadRequest, message)
+}
+
+func writeLegacyJSONErrorStatus(c *gin.Context, status int, message string) {
 	if c == nil {
 		return
 	}
-	c.JSON(http.StatusBadRequest, gin.H{
+	c.JSON(status, gin.H{
 		"msg":    message,
-		"status": http.StatusBadRequest,
+		"status": status,
 	})
 }

--- a/internal/access/api/conversation_sync.go
+++ b/internal/access/api/conversation_sync.go
@@ -6,6 +6,8 @@ import (
 
 	runtimechannelid "github.com/WuKongIM/WuKongIM/internal/runtime/channelid"
 	conversationusecase "github.com/WuKongIM/WuKongIM/internal/usecase/conversation"
+	"github.com/WuKongIM/WuKongIM/pkg/channel"
+	raftcluster "github.com/WuKongIM/WuKongIM/pkg/cluster"
 	"github.com/WuKongIM/WuKongIM/pkg/protocol/frame"
 	"github.com/gin-gonic/gin"
 )
@@ -91,7 +93,7 @@ func (s *Server) handleConversationClearUnread(c *gin.Context) {
 		ChannelType: req.ChannelType,
 		MessageSeq:  req.MessageSeq,
 	}); err != nil {
-		writeLegacyJSONError(c, err.Error())
+		writeConversationMutationError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK})
@@ -123,7 +125,7 @@ func (s *Server) handleConversationSetUnread(c *gin.Context) {
 		ChannelType: req.ChannelType,
 		Unread:      req.Unread,
 	}); err != nil {
-		writeLegacyJSONError(c, err.Error())
+		writeConversationMutationError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK})
@@ -155,10 +157,21 @@ func (s *Server) handleConversationDelete(c *gin.Context) {
 		ChannelType: req.ChannelType,
 		MessageSeq:  req.MessageSeq,
 	}); err != nil {
-		writeLegacyJSONError(c, err.Error())
+		writeConversationMutationError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK})
+}
+
+func writeConversationMutationError(c *gin.Context, err error) {
+	if errors.Is(err, channel.ErrNotReady) ||
+		errors.Is(err, channel.ErrStaleMeta) ||
+		errors.Is(err, channel.ErrNotLeader) ||
+		errors.Is(err, raftcluster.ErrNoLeader) {
+		writeLegacyJSONErrorStatus(c, http.StatusServiceUnavailable, "retry required")
+		return
+	}
+	writeLegacyJSONError(c, err.Error())
 }
 
 func validateClearConversationUnreadRequest(req clearConversationUnreadRequest) error {

--- a/internal/access/api/conversation_sync.go
+++ b/internal/access/api/conversation_sync.go
@@ -165,24 +165,35 @@ func (s *Server) handleConversationDelete(c *gin.Context) {
 }
 
 func (s *Server) writeConversationMutationError(c *gin.Context, err error) {
-	if errors.Is(err, channel.ErrNotReady) ||
-		errors.Is(err, channel.ErrStaleMeta) ||
-		errors.Is(err, channel.ErrNotLeader) ||
-		errors.Is(err, raftcluster.ErrNoLeader) {
+	status, message := classifyConversationMutationError(err)
+	switch {
+	case status == http.StatusServiceUnavailable:
 		if s != nil && s.logger != nil {
 			s.logger.Warn("conversation mutation temporarily unavailable", wklog.Error(err))
 		}
-		writeLegacyJSONErrorStatus(c, http.StatusServiceUnavailable, "retry required")
-		return
+	case status >= http.StatusInternalServerError:
+		if s != nil && s.logger != nil {
+			s.logger.Error("conversation mutation failed", wklog.Error(err))
+		}
 	}
-	if status, message, ok := mapSendError(err); ok {
-		writeLegacyJSONErrorStatus(c, status, message)
-		return
+	writeLegacyJSONErrorStatus(c, status, message)
+}
+
+func classifyConversationMutationError(err error) (int, string) {
+	switch {
+	case errors.Is(err, conversationusecase.ErrLatestMessageUnavailable):
+		return http.StatusConflict, "conversation has no latest message"
+	case errors.Is(err, channel.ErrNotReady),
+		errors.Is(err, channel.ErrStaleMeta),
+		errors.Is(err, channel.ErrNotLeader),
+		errors.Is(err, raftcluster.ErrNoLeader):
+		return http.StatusServiceUnavailable, "retry required"
+	default:
+		if status, message, ok := mapSendError(err); ok {
+			return status, message
+		}
+		return http.StatusInternalServerError, "conversation mutation failed"
 	}
-	if s != nil && s.logger != nil {
-		s.logger.Error("conversation mutation failed", wklog.Error(err))
-	}
-	writeLegacyJSONErrorStatus(c, http.StatusInternalServerError, "conversation mutation failed")
 }
 
 func validateClearConversationUnreadRequest(req clearConversationUnreadRequest) error {

--- a/internal/access/api/conversation_sync.go
+++ b/internal/access/api/conversation_sync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/WuKongIM/WuKongIM/pkg/channel"
 	raftcluster "github.com/WuKongIM/WuKongIM/pkg/cluster"
 	"github.com/WuKongIM/WuKongIM/pkg/protocol/frame"
+	"github.com/WuKongIM/WuKongIM/pkg/wklog"
 	"github.com/gin-gonic/gin"
 )
 
@@ -93,7 +94,7 @@ func (s *Server) handleConversationClearUnread(c *gin.Context) {
 		ChannelType: req.ChannelType,
 		MessageSeq:  req.MessageSeq,
 	}); err != nil {
-		writeConversationMutationError(c, err)
+		s.writeConversationMutationError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK})
@@ -125,7 +126,7 @@ func (s *Server) handleConversationSetUnread(c *gin.Context) {
 		ChannelType: req.ChannelType,
 		Unread:      req.Unread,
 	}); err != nil {
-		writeConversationMutationError(c, err)
+		s.writeConversationMutationError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK})
@@ -157,21 +158,31 @@ func (s *Server) handleConversationDelete(c *gin.Context) {
 		ChannelType: req.ChannelType,
 		MessageSeq:  req.MessageSeq,
 	}); err != nil {
-		writeConversationMutationError(c, err)
+		s.writeConversationMutationError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK})
 }
 
-func writeConversationMutationError(c *gin.Context, err error) {
+func (s *Server) writeConversationMutationError(c *gin.Context, err error) {
 	if errors.Is(err, channel.ErrNotReady) ||
 		errors.Is(err, channel.ErrStaleMeta) ||
 		errors.Is(err, channel.ErrNotLeader) ||
 		errors.Is(err, raftcluster.ErrNoLeader) {
+		if s != nil && s.logger != nil {
+			s.logger.Warn("conversation mutation temporarily unavailable", wklog.Error(err))
+		}
 		writeLegacyJSONErrorStatus(c, http.StatusServiceUnavailable, "retry required")
 		return
 	}
-	writeLegacyJSONError(c, err.Error())
+	if status, message, ok := mapSendError(err); ok {
+		writeLegacyJSONErrorStatus(c, status, message)
+		return
+	}
+	if s != nil && s.logger != nil {
+		s.logger.Error("conversation mutation failed", wklog.Error(err))
+	}
+	writeLegacyJSONErrorStatus(c, http.StatusInternalServerError, "conversation mutation failed")
 }
 
 func validateClearConversationUnreadRequest(req clearConversationUnreadRequest) error {

--- a/internal/access/api/server_test.go
+++ b/internal/access/api/server_test.go
@@ -1448,6 +1448,7 @@ func TestConversationMutationsReturnServiceUnavailableForRetryableClusterErrors(
 		{name: "stale metadata", err: channel.ErrStaleMeta},
 		{name: "not leader", err: channel.ErrNotLeader},
 		{name: "no leader", err: raftcluster.ErrNoLeader},
+		{name: "wrapped internal failure", err: errors.Join(channel.ErrNotReady, errors.New("dial tcp 10.0.0.2:11110: connection refused"))},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1461,6 +1462,34 @@ func TestConversationMutationsReturnServiceUnavailableForRetryableClusterErrors(
 
 			require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 			require.JSONEq(t, `{"msg":"retry required","status":503}`, rec.Body.String())
+		})
+	}
+}
+
+func TestConversationMutationsDoNotExposeInternalErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		status int
+		body   string
+	}{
+		{name: "channel not found", err: channel.ErrChannelNotFound, status: http.StatusNotFound, body: `{"msg":"channel not found","status":404}`},
+		{name: "channel deleting", err: channel.ErrChannelDeleting, status: http.StatusConflict, body: `{"msg":"channel deleting","status":409}`},
+		{name: "unknown internal failure", err: errors.New("dial tcp 10.0.0.2:11110: connection refused"), status: http.StatusInternalServerError, body: `{"msg":"conversation mutation failed","status":500}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conversations := &recordingConversationUsecase{setUnreadErr: tt.err}
+			srv := New(Options{Conversations: conversations})
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/conversations/setUnread", bytes.NewBufferString(`{"uid":"u1","channel_id":"g1","channel_type":2,"unread":3}`))
+			req.Header.Set("Content-Type", "application/json")
+			srv.Engine().ServeHTTP(rec, req)
+
+			require.Equal(t, tt.status, rec.Code)
+			require.JSONEq(t, tt.body, rec.Body.String())
+			require.NotContains(t, rec.Body.String(), "10.0.0.2")
 		})
 	}
 }

--- a/internal/access/api/server_test.go
+++ b/internal/access/api/server_test.go
@@ -1424,6 +1424,23 @@ func TestConversationDeleteMapsLegacyRequestToUsecaseCommand(t *testing.T) {
 	}, conversations.deleteCommands)
 }
 
+func TestConversationDeleteReturnsConflictWhenLatestMessageUnavailable(t *testing.T) {
+	conversations := &recordingConversationUsecase{
+		deleteErr: conversationusecase.ErrLatestMessageUnavailable,
+	}
+	srv := New(Options{Conversations: conversations})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/conversations/delete", bytes.NewBufferString(`{"uid":"u1","channel_id":"g1","channel_type":2}`))
+	req.Header.Set("Content-Type", "application/json")
+	srv.Engine().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusConflict, rec.Code)
+	require.JSONEq(t, `{"msg":"conversation has no latest message","status":409}`, rec.Body.String())
+	require.Len(t, conversations.deleteCommands, 1)
+	require.Zero(t, conversations.deleteCommands[0].MessageSeq)
+}
+
 func TestConversationSetUnreadRejectsInvalidLegacyRequest(t *testing.T) {
 	conversations := &recordingConversationUsecase{}
 	srv := New(Options{Conversations: conversations})

--- a/internal/access/api/server_test.go
+++ b/internal/access/api/server_test.go
@@ -18,6 +18,7 @@ import (
 	testdatausecase "github.com/WuKongIM/WuKongIM/internal/usecase/testdata"
 	"github.com/WuKongIM/WuKongIM/internal/usecase/user"
 	"github.com/WuKongIM/WuKongIM/pkg/channel"
+	raftcluster "github.com/WuKongIM/WuKongIM/pkg/cluster"
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
 	"github.com/WuKongIM/WuKongIM/pkg/protocol/frame"
 	"github.com/stretchr/testify/require"
@@ -1436,6 +1437,32 @@ func TestConversationSetUnreadRejectsInvalidLegacyRequest(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.JSONEq(t, `{"msg":"UID cannot be empty","status":400}`, rec.Body.String())
 	require.Empty(t, conversations.setUnreadCommands)
+}
+
+func TestConversationMutationsReturnServiceUnavailableForRetryableClusterErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "not ready", err: channel.ErrNotReady},
+		{name: "stale metadata", err: channel.ErrStaleMeta},
+		{name: "not leader", err: channel.ErrNotLeader},
+		{name: "no leader", err: raftcluster.ErrNoLeader},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conversations := &recordingConversationUsecase{setUnreadErr: tt.err}
+			srv := New(Options{Conversations: conversations})
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/conversations/setUnread", bytes.NewBufferString(`{"uid":"u1","channel_id":"g1","channel_type":2,"unread":3}`))
+			req.Header.Set("Content-Type", "application/json")
+			srv.Engine().ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+			require.JSONEq(t, `{"msg":"retry required","status":503}`, rec.Body.String())
+		})
+	}
 }
 
 type recordingMessageUsecase struct {

--- a/internal/access/node/channel_append_rpc_test.go
+++ b/internal/access/node/channel_append_rpc_test.go
@@ -591,6 +591,8 @@ func (s *stubNodeMetaRefresher) RefreshChannelMeta(context.Context, channel.Chan
 	return s.meta, s.err
 }
 
+func (s *stubNodeMetaRefresher) InvalidateChannelMeta(channel.ChannelID) {}
+
 type remoteErrorCluster struct {
 	err error
 }

--- a/internal/access/node/channel_append_rpc_test.go
+++ b/internal/access/node/channel_append_rpc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/WuKongIM/WuKongIM/internal/runtime/online"
 	"github.com/WuKongIM/WuKongIM/internal/usecase/presence"
 	"github.com/WuKongIM/WuKongIM/pkg/channel"
+	channelruntime "github.com/WuKongIM/WuKongIM/pkg/channel/runtime"
 	raftcluster "github.com/WuKongIM/WuKongIM/pkg/cluster"
 	"github.com/WuKongIM/WuKongIM/pkg/protocol/frame"
 	"github.com/WuKongIM/WuKongIM/pkg/slot/multiraft"
@@ -589,6 +590,10 @@ type stubNodeMetaRefresher struct {
 
 func (s *stubNodeMetaRefresher) RefreshChannelMeta(context.Context, channel.ChannelID) (channel.Meta, error) {
 	return s.meta, s.err
+}
+
+func (s *stubNodeMetaRefresher) ActivateByID(ctx context.Context, id channel.ChannelID, _ channelruntime.ActivationSource) (channel.Meta, error) {
+	return s.RefreshChannelMeta(ctx, id)
 }
 
 func (s *stubNodeMetaRefresher) InvalidateChannelMeta(channel.ChannelID) {}

--- a/internal/access/node/channel_plane_rpc_test.go
+++ b/internal/access/node/channel_plane_rpc_test.go
@@ -90,3 +90,5 @@ func (r *recordingNodeMetaRefresher) RefreshChannelMeta(context.Context, channel
 	r.calls++
 	return channel.Meta{}, nil
 }
+
+func (r *recordingNodeMetaRefresher) InvalidateChannelMeta(channel.ChannelID) {}

--- a/internal/access/node/channel_plane_rpc_test.go
+++ b/internal/access/node/channel_plane_rpc_test.go
@@ -6,6 +6,7 @@ import (
 
 	runtimechannelplane "github.com/WuKongIM/WuKongIM/internal/runtime/channelplane"
 	"github.com/WuKongIM/WuKongIM/pkg/channel"
+	channelruntime "github.com/WuKongIM/WuKongIM/pkg/channel/runtime"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,6 +90,10 @@ type recordingNodeMetaRefresher struct {
 func (r *recordingNodeMetaRefresher) RefreshChannelMeta(context.Context, channel.ChannelID) (channel.Meta, error) {
 	r.calls++
 	return channel.Meta{}, nil
+}
+
+func (r *recordingNodeMetaRefresher) ActivateByID(ctx context.Context, id channel.ChannelID, _ channelruntime.ActivationSource) (channel.Meta, error) {
+	return r.RefreshChannelMeta(ctx, id)
 }
 
 func (r *recordingNodeMetaRefresher) InvalidateChannelMeta(channel.ChannelID) {}

--- a/internal/access/node/client.go
+++ b/internal/access/node/client.go
@@ -390,6 +390,36 @@ func (c *Client) LoadLatestConversationMessage(ctx context.Context, nodeID uint6
 	return resp.Messages[0], true, nil
 }
 
+func (c *Client) LoadLatestConversationMessageAuthoritative(ctx context.Context, nodeID uint64, key channel.ChannelID, maxBytes int, expectedChannelEpoch, expectedLeaderEpoch uint64) (channel.Message, bool, error) {
+	resp, err := callConversationFactsDirect(ctx, c, nodeID, conversationFactsRequest{
+		Op:                   conversationFactsOpLatestAuthoritative,
+		Key:                  newConversationFactsChannelKey(key),
+		MaxBytes:             maxBytes,
+		ExpectedChannelEpoch: expectedChannelEpoch,
+		ExpectedLeaderEpoch:  expectedLeaderEpoch,
+	})
+	if err != nil {
+		return channel.Message{}, false, normalizeConversationFactsRPCError(err)
+	}
+	switch resp.Status {
+	case rpcStatusOK:
+	case rpcStatusNotLeader:
+		return channel.Message{}, false, channel.ErrNotLeader
+	case rpcStatusNoLeader:
+		return channel.Message{}, false, raftcluster.ErrNoLeader
+	case conversationFactsStatusNotReady:
+		return channel.Message{}, false, channel.ErrNotReady
+	case conversationFactsStatusStaleMeta:
+		return channel.Message{}, false, channel.ErrStaleMeta
+	default:
+		return channel.Message{}, false, fmt.Errorf("access/node: unexpected authoritative conversation facts status %q", resp.Status)
+	}
+	if len(resp.Messages) == 0 {
+		return channel.Message{}, false, nil
+	}
+	return resp.Messages[0], true, nil
+}
+
 func (c *Client) LoadLatestConversationMessages(ctx context.Context, nodeID uint64, keys []channel.ChannelID, maxBytes int) (map[channel.ChannelID]channel.Message, error) {
 	resp, err := callConversationFactsDirect(ctx, c, nodeID, conversationFactsRequest{
 		Op:       conversationFactsOpLatest,
@@ -480,6 +510,31 @@ func callConversationFactsDirect(ctx context.Context, c *Client, nodeID uint64, 
 		return conversationFactsResponse{}, err
 	}
 	return decodeConversationFactsResponse(respBody)
+}
+
+func normalizeConversationFactsRPCError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, channel.ErrNotLeader) ||
+		errors.Is(err, channel.ErrStaleMeta) ||
+		errors.Is(err, channel.ErrNotReady) ||
+		errors.Is(err, raftcluster.ErrNoLeader) {
+		return err
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, channel.ErrNotLeader.Error()):
+		return channel.ErrNotLeader
+	case strings.Contains(msg, channel.ErrStaleMeta.Error()):
+		return channel.ErrStaleMeta
+	case strings.Contains(msg, channel.ErrNotReady.Error()):
+		return channel.ErrNotReady
+	case strings.Contains(msg, raftcluster.ErrNoLeader.Error()):
+		return raftcluster.ErrNoLeader
+	default:
+		return err
+	}
 }
 
 func callAuthoritativeRPC[T authoritativeRPCResponse](

--- a/internal/access/node/client.go
+++ b/internal/access/node/client.go
@@ -541,7 +541,7 @@ func normalizeConversationFactsRPCError(err error) error {
 		strings.Contains(msg, "unsupported conversation facts op"):
 		return fmt.Errorf("%w: peer does not support authoritative conversation facts", channel.ErrNotReady)
 	default:
-		return fmt.Errorf("%w: %w: %v", ErrConversationFactsRouteUnavailable, channel.ErrNotReady, err)
+		return fmt.Errorf("%w: %w: %w", ErrConversationFactsRouteUnavailable, channel.ErrNotReady, err)
 	}
 }
 
@@ -553,6 +553,10 @@ func conversationFactsResponseError(status string) error {
 		return channel.ErrNotLeader
 	case rpcStatusNoLeader:
 		return raftcluster.ErrNoLeader
+	case conversationFactsStatusChannelDeleting:
+		return channel.ErrChannelDeleting
+	case conversationFactsStatusChannelNotFound:
+		return channel.ErrChannelNotFound
 	case conversationFactsStatusNotReady:
 		return channel.ErrNotReady
 	case conversationFactsStatusStaleMeta:

--- a/internal/access/node/client.go
+++ b/internal/access/node/client.go
@@ -534,12 +534,14 @@ func normalizeConversationFactsRPCError(err error) error {
 		return channel.ErrNotReady
 	case strings.Contains(msg, raftcluster.ErrNoLeader.Error()):
 		return raftcluster.ErrNoLeader
+	// These fragments are a temporary wire-compatibility contract with peers
+	// that predate the authoritative conversation-facts operation.
 	case strings.Contains(msg, "invalid conversation facts request codec"),
 		strings.Contains(msg, "unknown conversation facts op"),
 		strings.Contains(msg, "unsupported conversation facts op"):
 		return fmt.Errorf("%w: peer does not support authoritative conversation facts", channel.ErrNotReady)
 	default:
-		return err
+		return fmt.Errorf("%w: %w: %v", ErrConversationFactsRouteUnavailable, channel.ErrNotReady, err)
 	}
 }
 

--- a/internal/access/node/client.go
+++ b/internal/access/node/client.go
@@ -384,6 +384,9 @@ func (c *Client) LoadLatestConversationMessage(ctx context.Context, nodeID uint6
 	if err != nil {
 		return channel.Message{}, false, err
 	}
+	if err := conversationFactsResponseError(resp.Status); err != nil {
+		return channel.Message{}, false, err
+	}
 	if len(resp.Messages) == 0 {
 		return channel.Message{}, false, nil
 	}
@@ -401,18 +404,8 @@ func (c *Client) LoadLatestConversationMessageAuthoritative(ctx context.Context,
 	if err != nil {
 		return channel.Message{}, false, normalizeConversationFactsRPCError(err)
 	}
-	switch resp.Status {
-	case rpcStatusOK:
-	case rpcStatusNotLeader:
-		return channel.Message{}, false, channel.ErrNotLeader
-	case rpcStatusNoLeader:
-		return channel.Message{}, false, raftcluster.ErrNoLeader
-	case conversationFactsStatusNotReady:
-		return channel.Message{}, false, channel.ErrNotReady
-	case conversationFactsStatusStaleMeta:
-		return channel.Message{}, false, channel.ErrStaleMeta
-	default:
-		return channel.Message{}, false, fmt.Errorf("access/node: unexpected authoritative conversation facts status %q", resp.Status)
+	if err := conversationFactsResponseError(resp.Status); err != nil {
+		return channel.Message{}, false, err
 	}
 	if len(resp.Messages) == 0 {
 		return channel.Message{}, false, nil
@@ -427,6 +420,9 @@ func (c *Client) LoadLatestConversationMessages(ctx context.Context, nodeID uint
 		MaxBytes: maxBytes,
 	})
 	if err != nil {
+		return nil, err
+	}
+	if err := conversationFactsResponseError(resp.Status); err != nil {
 		return nil, err
 	}
 	out := make(map[channel.ChannelID]channel.Message, len(resp.Entries))
@@ -449,6 +445,9 @@ func (c *Client) LoadRecentConversationMessages(ctx context.Context, nodeID uint
 	if err != nil {
 		return nil, err
 	}
+	if err := conversationFactsResponseError(resp.Status); err != nil {
+		return nil, err
+	}
 	return append([]channel.Message(nil), resp.Messages...), nil
 }
 
@@ -460,6 +459,9 @@ func (c *Client) LoadRecentConversationMessagesBatch(ctx context.Context, nodeID
 		MaxBytes: maxBytes,
 	})
 	if err != nil {
+		return nil, err
+	}
+	if err := conversationFactsResponseError(resp.Status); err != nil {
 		return nil, err
 	}
 	out := make(map[channel.ChannelID][]channel.Message, len(resp.Entries))
@@ -532,8 +534,29 @@ func normalizeConversationFactsRPCError(err error) error {
 		return channel.ErrNotReady
 	case strings.Contains(msg, raftcluster.ErrNoLeader.Error()):
 		return raftcluster.ErrNoLeader
+	case strings.Contains(msg, "invalid conversation facts request codec"),
+		strings.Contains(msg, "unknown conversation facts op"),
+		strings.Contains(msg, "unsupported conversation facts op"):
+		return fmt.Errorf("%w: peer does not support authoritative conversation facts", channel.ErrNotReady)
 	default:
 		return err
+	}
+}
+
+func conversationFactsResponseError(status string) error {
+	switch status {
+	case rpcStatusOK:
+		return nil
+	case rpcStatusNotLeader:
+		return channel.ErrNotLeader
+	case rpcStatusNoLeader:
+		return raftcluster.ErrNoLeader
+	case conversationFactsStatusNotReady:
+		return channel.ErrNotReady
+	case conversationFactsStatusStaleMeta:
+		return channel.ErrStaleMeta
+	default:
+		return fmt.Errorf("access/node: unexpected conversation facts status %q", status)
 	}
 }
 

--- a/internal/access/node/conversation_facts_codec.go
+++ b/internal/access/node/conversation_facts_codec.go
@@ -3,19 +3,29 @@ package node
 import "fmt"
 
 var (
-	conversationFactsRequestMagic  = [...]byte{'W', 'K', 'C', 'F', 1}
-	conversationFactsResponseMagic = [...]byte{'W', 'K', 'C', 'G', 1}
+	conversationFactsRequestMagicV1 = [...]byte{'W', 'K', 'C', 'F', 1}
+	conversationFactsRequestMagicV2 = [...]byte{'W', 'K', 'C', 'F', 2}
+	conversationFactsResponseMagic  = [...]byte{'W', 'K', 'C', 'G', 1}
 )
 
 // encodeConversationFactsRequestBinary encodes conversation fact lookups without JSON reflection.
 func encodeConversationFactsRequestBinary(req conversationFactsRequest) ([]byte, error) {
-	dst := make([]byte, 0, len(conversationFactsRequestMagic)+128+len(req.Op))
-	dst = append(dst, conversationFactsRequestMagic[:]...)
+	useV2 := req.Op == conversationFactsOpLatestAuthoritative || req.ExpectedChannelEpoch != 0 || req.ExpectedLeaderEpoch != 0
+	magic := conversationFactsRequestMagicV1[:]
+	if useV2 {
+		magic = conversationFactsRequestMagicV2[:]
+	}
+	dst := make([]byte, 0, len(magic)+144+len(req.Op))
+	dst = append(dst, magic...)
 	dst = appendString(dst, req.Op)
 	dst = appendConversationFactsChannelKey(dst, req.Key)
 	dst = appendConversationFactsChannelKeys(dst, req.Keys)
 	dst = appendNodeInt(dst, req.Limit)
 	dst = appendNodeInt(dst, req.MaxBytes)
+	if useV2 {
+		dst = appendUvarint(dst, req.ExpectedChannelEpoch)
+		dst = appendUvarint(dst, req.ExpectedLeaderEpoch)
+	}
 	return dst, nil
 }
 
@@ -23,7 +33,8 @@ func decodeConversationFactsRequest(body []byte) (conversationFactsRequest, erro
 	if !isConversationFactsRequestBinary(body) {
 		return conversationFactsRequest{}, fmt.Errorf("access/node: invalid conversation facts request codec")
 	}
-	offset := len(conversationFactsRequestMagic)
+	isV2 := hasMagic(body, conversationFactsRequestMagicV2[:])
+	offset := len(conversationFactsRequestMagicV1)
 	var req conversationFactsRequest
 	var err error
 	if req.Op, offset, err = readString(body, offset); err != nil {
@@ -40,6 +51,14 @@ func decodeConversationFactsRequest(body []byte) (conversationFactsRequest, erro
 	}
 	if req.MaxBytes, offset, err = readNodeInt(body, offset, "conversation facts max bytes"); err != nil {
 		return conversationFactsRequest{}, err
+	}
+	if isV2 {
+		if req.ExpectedChannelEpoch, offset, err = readUvarint(body, offset); err != nil {
+			return conversationFactsRequest{}, err
+		}
+		if req.ExpectedLeaderEpoch, offset, err = readUvarint(body, offset); err != nil {
+			return conversationFactsRequest{}, err
+		}
 	}
 	if offset != len(body) {
 		return conversationFactsRequest{}, fmt.Errorf("access/node: trailing conversation facts request bytes")
@@ -79,7 +98,7 @@ func decodeConversationFactsResponseBinary(body []byte) (conversationFactsRespon
 }
 
 func isConversationFactsRequestBinary(body []byte) bool {
-	return hasMagic(body, conversationFactsRequestMagic[:])
+	return hasMagic(body, conversationFactsRequestMagicV1[:]) || hasMagic(body, conversationFactsRequestMagicV2[:])
 }
 
 func isConversationFactsResponseBinary(body []byte) bool {

--- a/internal/access/node/conversation_facts_codec.go
+++ b/internal/access/node/conversation_facts_codec.go
@@ -35,6 +35,9 @@ func decodeConversationFactsRequest(body []byte) (conversationFactsRequest, erro
 	}
 	isV2 := hasMagic(body, conversationFactsRequestMagicV2[:])
 	offset := len(conversationFactsRequestMagicV1)
+	if isV2 {
+		offset = len(conversationFactsRequestMagicV2)
+	}
 	var req conversationFactsRequest
 	var err error
 	if req.Op, offset, err = readString(body, offset); err != nil {

--- a/internal/access/node/conversation_facts_rpc.go
+++ b/internal/access/node/conversation_facts_rpc.go
@@ -17,6 +17,8 @@ const (
 	conversationFactsStatusStaleMeta       = "stale_meta"
 )
 
+var errConversationFactsLocalRuntimeStale = errors.New("access/node: local conversation facts runtime stale")
+
 type conversationFactsChannelKey struct {
 	ID   string
 	Type uint8
@@ -166,7 +168,7 @@ func (a *Adapter) loadLatestConversationFactAuthoritative(ctx context.Context, i
 		expectedChannelEpoch,
 		expectedLeaderEpoch,
 	)
-	if !errors.Is(err, channel.ErrStaleMeta) {
+	if !errors.Is(err, errConversationFactsLocalRuntimeStale) {
 		return msg, ok, err
 	}
 	if _, refreshErr := a.refreshConversationFactsMeta(ctx, id); refreshErr != nil {
@@ -205,6 +207,7 @@ func (a *Adapter) refreshConversationFactsMeta(ctx context.Context, id channel.C
 	if a == nil || a.channelMeta == nil {
 		return channel.Meta{}, channel.ErrStaleMeta
 	}
+	a.channelMeta.InvalidateChannelMeta(id)
 	return a.channelMeta.RefreshChannelMeta(ctx, id)
 }
 
@@ -241,6 +244,9 @@ func loadLatestConversationMessageAuthoritative(ctx context.Context, cluster Cha
 	}
 	status, err := cluster.Status(id)
 	if err != nil {
+		if errors.Is(err, channel.ErrStaleMeta) {
+			return channel.Message{}, false, fmt.Errorf("%w: %w", errConversationFactsLocalRuntimeStale, err)
+		}
 		return channel.Message{}, false, err
 	}
 	if status.Leader == 0 {

--- a/internal/access/node/conversation_facts_rpc.go
+++ b/internal/access/node/conversation_facts_rpc.go
@@ -6,11 +6,15 @@ import (
 	"fmt"
 
 	"github.com/WuKongIM/WuKongIM/pkg/channel"
+	raftcluster "github.com/WuKongIM/WuKongIM/pkg/cluster"
 )
 
 const (
-	conversationFactsOpLatest = "latest"
-	conversationFactsOpRecent = "recent"
+	conversationFactsOpLatest              = "latest"
+	conversationFactsOpLatestAuthoritative = "latest_authoritative"
+	conversationFactsOpRecent              = "recent"
+	conversationFactsStatusNotReady        = "not_ready"
+	conversationFactsStatusStaleMeta       = "stale_meta"
 )
 
 type conversationFactsChannelKey struct {
@@ -19,11 +23,13 @@ type conversationFactsChannelKey struct {
 }
 
 type conversationFactsRequest struct {
-	Op       string                        `json:"op"`
-	Key      conversationFactsChannelKey   `json:"key"`
-	Keys     []conversationFactsChannelKey `json:"keys,omitempty"`
-	Limit    int                           `json:"limit,omitempty"`
-	MaxBytes int                           `json:"max_bytes,omitempty"`
+	Op                   string                        `json:"op"`
+	Key                  conversationFactsChannelKey   `json:"key"`
+	Keys                 []conversationFactsChannelKey `json:"keys,omitempty"`
+	Limit                int                           `json:"limit,omitempty"`
+	MaxBytes             int                           `json:"max_bytes,omitempty"`
+	ExpectedChannelEpoch uint64                        `json:"expected_channel_epoch,omitempty"`
+	ExpectedLeaderEpoch  uint64                        `json:"expected_leader_epoch,omitempty"`
 }
 
 type conversationFactsEntry struct {
@@ -56,6 +62,9 @@ func (a *Adapter) handleConversationFactsRPC(ctx context.Context, body []byte) (
 		entries  []conversationFactsEntry
 	)
 	if len(req.Keys) > 0 {
+		if req.Op == conversationFactsOpLatestAuthoritative {
+			return nil, fmt.Errorf("access/node: authoritative conversation facts require one channel")
+		}
 		entries = make([]conversationFactsEntry, 0, len(req.Keys))
 		for _, rawKey := range req.Keys {
 			key := rawKey.channelID()
@@ -96,6 +105,19 @@ func (a *Adapter) handleConversationFactsRPC(ctx context.Context, body []byte) (
 		if ok {
 			messages = []channel.Message{msg}
 		}
+	case conversationFactsOpLatestAuthoritative:
+		var msg channel.Message
+		var ok bool
+		msg, ok, err = a.loadLatestConversationFactAuthoritative(
+			ctx,
+			key,
+			req.MaxBytes,
+			req.ExpectedChannelEpoch,
+			req.ExpectedLeaderEpoch,
+		)
+		if ok {
+			messages = []channel.Message{msg}
+		}
 	case conversationFactsOpRecent:
 		messages, err = a.loadRecentConversationFacts(ctx, key, req.Limit, req.MaxBytes)
 	default:
@@ -105,6 +127,9 @@ func (a *Adapter) handleConversationFactsRPC(ctx context.Context, body []byte) (
 		err = nil
 	}
 	if err != nil {
+		if status, ok := conversationFactsErrorStatus(err); ok {
+			return encodeConversationFactsResponse(conversationFactsResponse{Status: status})
+		}
 		return nil, err
 	}
 	return encodeConversationFactsResponse(conversationFactsResponse{
@@ -114,25 +139,66 @@ func (a *Adapter) handleConversationFactsRPC(ctx context.Context, body []byte) (
 }
 
 func (a *Adapter) loadLatestConversationFact(ctx context.Context, id channel.ChannelID, maxBytes int) (channel.Message, bool, error) {
-	msg, ok, err := loadLatestConversationMessage(ctx, a.channelLog, id, maxBytes)
+	msg, ok, err := loadLatestConversationMessageStrict(ctx, a.channelLog, id, maxBytes)
+	if errors.Is(err, channel.ErrNotReady) {
+		return channel.Message{}, false, nil
+	}
 	if !errors.Is(err, channel.ErrStaleMeta) {
 		return msg, ok, err
 	}
 	if _, refreshErr := a.refreshConversationFactsMeta(ctx, id); refreshErr != nil {
 		return channel.Message{}, false, refreshErr
 	}
-	return loadLatestConversationMessage(ctx, a.channelLog, id, maxBytes)
+	msg, ok, err = loadLatestConversationMessageStrict(ctx, a.channelLog, id, maxBytes)
+	if errors.Is(err, channel.ErrNotReady) {
+		return channel.Message{}, false, nil
+	}
+	return msg, ok, err
+}
+
+func (a *Adapter) loadLatestConversationFactAuthoritative(ctx context.Context, id channel.ChannelID, maxBytes int, expectedChannelEpoch, expectedLeaderEpoch uint64) (channel.Message, bool, error) {
+	msg, ok, err := loadLatestConversationMessageAuthoritative(
+		ctx,
+		a.channelLog,
+		id,
+		maxBytes,
+		a.localNodeID,
+		expectedChannelEpoch,
+		expectedLeaderEpoch,
+	)
+	if !errors.Is(err, channel.ErrStaleMeta) {
+		return msg, ok, err
+	}
+	if _, refreshErr := a.refreshConversationFactsMeta(ctx, id); refreshErr != nil {
+		return channel.Message{}, false, refreshErr
+	}
+	return loadLatestConversationMessageAuthoritative(
+		ctx,
+		a.channelLog,
+		id,
+		maxBytes,
+		a.localNodeID,
+		expectedChannelEpoch,
+		expectedLeaderEpoch,
+	)
 }
 
 func (a *Adapter) loadRecentConversationFacts(ctx context.Context, id channel.ChannelID, limit, maxBytes int) ([]channel.Message, error) {
-	messages, err := loadRecentConversationMessages(ctx, a.channelLog, id, limit, maxBytes)
+	messages, err := loadRecentConversationMessagesStrict(ctx, a.channelLog, id, limit, maxBytes)
+	if errors.Is(err, channel.ErrNotReady) {
+		return nil, nil
+	}
 	if !errors.Is(err, channel.ErrStaleMeta) {
 		return messages, err
 	}
 	if _, refreshErr := a.refreshConversationFactsMeta(ctx, id); refreshErr != nil {
 		return nil, refreshErr
 	}
-	return loadRecentConversationMessages(ctx, a.channelLog, id, limit, maxBytes)
+	messages, err = loadRecentConversationMessagesStrict(ctx, a.channelLog, id, limit, maxBytes)
+	if errors.Is(err, channel.ErrNotReady) {
+		return nil, nil
+	}
+	return messages, err
 }
 
 func (a *Adapter) refreshConversationFactsMeta(ctx context.Context, id channel.ChannelID) (channel.Meta, error) {
@@ -142,7 +208,7 @@ func (a *Adapter) refreshConversationFactsMeta(ctx context.Context, id channel.C
 	return a.channelMeta.RefreshChannelMeta(ctx, id)
 }
 
-func loadLatestConversationMessage(ctx context.Context, cluster ChannelLog, id channel.ChannelID, maxBytes int) (channel.Message, bool, error) {
+func loadLatestConversationMessageStrict(ctx context.Context, cluster ChannelLog, id channel.ChannelID, maxBytes int) (channel.Message, bool, error) {
 	if cluster == nil {
 		return channel.Message{}, false, channel.ErrStaleMeta
 	}
@@ -169,7 +235,62 @@ func loadLatestConversationMessage(ctx context.Context, cluster ChannelLog, id c
 	return fetch.Messages[0], true, nil
 }
 
-func loadRecentConversationMessages(ctx context.Context, cluster ChannelLog, id channel.ChannelID, limit, maxBytes int) ([]channel.Message, error) {
+func loadLatestConversationMessageAuthoritative(ctx context.Context, cluster ChannelLog, id channel.ChannelID, maxBytes int, localNodeID, expectedChannelEpoch, expectedLeaderEpoch uint64) (channel.Message, bool, error) {
+	if cluster == nil || localNodeID == 0 {
+		return channel.Message{}, false, channel.ErrStaleMeta
+	}
+	status, err := cluster.Status(id)
+	if err != nil {
+		return channel.Message{}, false, err
+	}
+	if status.Leader == 0 {
+		return channel.Message{}, false, raftcluster.ErrNoLeader
+	}
+	if uint64(status.Leader) != localNodeID {
+		return channel.Message{}, false, channel.ErrNotLeader
+	}
+	if expectedLeaderEpoch != 0 && status.LeaderEpoch != expectedLeaderEpoch {
+		return channel.Message{}, false, channel.ErrStaleMeta
+	}
+
+	fromSeq := status.CommittedSeq
+	if fromSeq == 0 {
+		fromSeq = 1
+	}
+	fetch, err := cluster.Fetch(ctx, channel.FetchRequest{
+		ChannelID:            id,
+		FromSeq:              fromSeq,
+		Limit:                1,
+		MaxBytes:             maxBytes,
+		ExpectedChannelEpoch: expectedChannelEpoch,
+		ExpectedLeaderEpoch:  expectedLeaderEpoch,
+		RequireLeader:        true,
+	})
+	if err != nil {
+		return channel.Message{}, false, err
+	}
+	if status.CommittedSeq == 0 || len(fetch.Messages) == 0 {
+		return channel.Message{}, false, nil
+	}
+	return fetch.Messages[0], true, nil
+}
+
+func conversationFactsErrorStatus(err error) (string, bool) {
+	switch {
+	case errors.Is(err, channel.ErrNotLeader):
+		return rpcStatusNotLeader, true
+	case errors.Is(err, channel.ErrNotReady):
+		return conversationFactsStatusNotReady, true
+	case errors.Is(err, channel.ErrStaleMeta):
+		return conversationFactsStatusStaleMeta, true
+	case errors.Is(err, raftcluster.ErrNoLeader):
+		return rpcStatusNoLeader, true
+	default:
+		return "", false
+	}
+}
+
+func loadRecentConversationMessagesStrict(ctx context.Context, cluster ChannelLog, id channel.ChannelID, limit, maxBytes int) ([]channel.Message, error) {
 	if cluster == nil || limit <= 0 {
 		return nil, nil
 	}

--- a/internal/access/node/conversation_facts_rpc.go
+++ b/internal/access/node/conversation_facts_rpc.go
@@ -14,6 +14,8 @@ const (
 	conversationFactsOpLatest              = "latest"
 	conversationFactsOpLatestAuthoritative = "latest_authoritative"
 	conversationFactsOpRecent              = "recent"
+	conversationFactsStatusChannelDeleting = "channel_deleting"
+	conversationFactsStatusChannelNotFound = "channel_not_found"
 	conversationFactsStatusNotReady        = "not_ready"
 	conversationFactsStatusStaleMeta       = "stale_meta"
 )
@@ -131,12 +133,14 @@ func (a *Adapter) handleConversationFactsRPC(ctx context.Context, body []byte) (
 	default:
 		return nil, fmt.Errorf("access/node: unknown conversation facts op %q", req.Op)
 	}
-	if errors.Is(err, channel.ErrChannelNotFound) {
+	if req.Op != conversationFactsOpLatestAuthoritative && errors.Is(err, channel.ErrChannelNotFound) {
 		err = nil
 	}
 	if err != nil {
-		if status, ok := conversationFactsErrorStatus(err); ok {
-			return encodeConversationFactsResponse(conversationFactsResponse{Status: status})
+		if req.Op == conversationFactsOpLatestAuthoritative {
+			if status, ok := conversationFactsErrorStatus(err); ok {
+				return encodeConversationFactsResponse(conversationFactsResponse{Status: status})
+			}
 		}
 		return nil, err
 	}
@@ -286,9 +290,6 @@ func LoadLatestConversationMessageAuthoritative(ctx context.Context, cluster Con
 		ExpectedLeaderEpoch:  expectedLeaderEpoch,
 		RequireLeader:        true,
 	})
-	if errors.Is(err, channel.ErrChannelNotFound) {
-		return channel.Message{}, false, nil
-	}
 	if err != nil {
 		return channel.Message{}, false, err
 	}
@@ -300,6 +301,10 @@ func LoadLatestConversationMessageAuthoritative(ctx context.Context, cluster Con
 
 func conversationFactsErrorStatus(err error) (string, bool) {
 	switch {
+	case errors.Is(err, channel.ErrChannelDeleting):
+		return conversationFactsStatusChannelDeleting, true
+	case errors.Is(err, channel.ErrChannelNotFound):
+		return conversationFactsStatusChannelNotFound, true
 	case errors.Is(err, channel.ErrNotLeader):
 		return rpcStatusNotLeader, true
 	case errors.Is(err, channel.ErrNotReady):

--- a/internal/access/node/conversation_facts_rpc.go
+++ b/internal/access/node/conversation_facts_rpc.go
@@ -147,9 +147,6 @@ func loadLatestConversationMessage(ctx context.Context, cluster ChannelLog, id c
 		return channel.Message{}, false, channel.ErrStaleMeta
 	}
 	status, err := cluster.Status(id)
-	if errors.Is(err, channel.ErrNotReady) {
-		return channel.Message{}, false, nil
-	}
 	if err != nil {
 		return channel.Message{}, false, err
 	}
@@ -163,9 +160,6 @@ func loadLatestConversationMessage(ctx context.Context, cluster ChannelLog, id c
 		Limit:     1,
 		MaxBytes:  maxBytes,
 	})
-	if errors.Is(err, channel.ErrNotReady) {
-		return channel.Message{}, false, nil
-	}
 	if err != nil {
 		return channel.Message{}, false, err
 	}
@@ -180,9 +174,6 @@ func loadRecentConversationMessages(ctx context.Context, cluster ChannelLog, id 
 		return nil, nil
 	}
 	status, err := cluster.Status(id)
-	if errors.Is(err, channel.ErrNotReady) {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -200,9 +191,6 @@ func loadRecentConversationMessages(ctx context.Context, cluster ChannelLog, id 
 		Limit:     limit,
 		MaxBytes:  maxBytes,
 	})
-	if errors.Is(err, channel.ErrNotReady) {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/access/node/conversation_facts_rpc.go
+++ b/internal/access/node/conversation_facts_rpc.go
@@ -17,7 +17,12 @@ const (
 	conversationFactsStatusStaleMeta       = "stale_meta"
 )
 
-var errConversationFactsLocalRuntimeStale = errors.New("access/node: local conversation facts runtime stale")
+var (
+	// ErrConversationFactsRouteUnavailable marks peer RPC failures that should
+	// invalidate channel routing and retry once before surfacing as unavailable.
+	ErrConversationFactsRouteUnavailable  = errors.New("access/node: conversation facts route unavailable")
+	errConversationFactsLocalRuntimeStale = errors.New("access/node: local conversation facts runtime stale")
+)
 
 type conversationFactsChannelKey struct {
 	ID   string
@@ -159,7 +164,7 @@ func (a *Adapter) loadLatestConversationFact(ctx context.Context, id channel.Cha
 }
 
 func (a *Adapter) loadLatestConversationFactAuthoritative(ctx context.Context, id channel.ChannelID, maxBytes int, expectedChannelEpoch, expectedLeaderEpoch uint64) (channel.Message, bool, error) {
-	msg, ok, err := loadLatestConversationMessageAuthoritative(
+	msg, ok, err := LoadLatestConversationMessageAuthoritative(
 		ctx,
 		a.channelLog,
 		id,
@@ -174,7 +179,7 @@ func (a *Adapter) loadLatestConversationFactAuthoritative(ctx context.Context, i
 	if _, refreshErr := a.refreshConversationFactsMeta(ctx, id); refreshErr != nil {
 		return channel.Message{}, false, refreshErr
 	}
-	return loadLatestConversationMessageAuthoritative(
+	return LoadLatestConversationMessageAuthoritative(
 		ctx,
 		a.channelLog,
 		id,
@@ -238,7 +243,15 @@ func loadLatestConversationMessageStrict(ctx context.Context, cluster ChannelLog
 	return fetch.Messages[0], true, nil
 }
 
-func loadLatestConversationMessageAuthoritative(ctx context.Context, cluster ChannelLog, id channel.ChannelID, maxBytes int, localNodeID, expectedChannelEpoch, expectedLeaderEpoch uint64) (channel.Message, bool, error) {
+// ConversationFactsLog is the narrow channel-log view required by conversation reads.
+type ConversationFactsLog interface {
+	Status(id channel.ChannelID) (channel.ChannelRuntimeStatus, error)
+	Fetch(ctx context.Context, req channel.FetchRequest) (channel.FetchResult, error)
+}
+
+// LoadLatestConversationMessageAuthoritative returns the latest committed
+// message only when the local replica proves it is still authoritative.
+func LoadLatestConversationMessageAuthoritative(ctx context.Context, cluster ConversationFactsLog, id channel.ChannelID, maxBytes int, localNodeID, expectedChannelEpoch, expectedLeaderEpoch uint64) (channel.Message, bool, error) {
 	if cluster == nil || localNodeID == 0 {
 		return channel.Message{}, false, channel.ErrStaleMeta
 	}
@@ -272,10 +285,13 @@ func loadLatestConversationMessageAuthoritative(ctx context.Context, cluster Cha
 		ExpectedLeaderEpoch:  expectedLeaderEpoch,
 		RequireLeader:        true,
 	})
+	if errors.Is(err, channel.ErrChannelNotFound) {
+		return channel.Message{}, false, nil
+	}
 	if err != nil {
 		return channel.Message{}, false, err
 	}
-	if status.CommittedSeq == 0 || len(fetch.Messages) == 0 {
+	if len(fetch.Messages) == 0 {
 		return channel.Message{}, false, nil
 	}
 	return fetch.Messages[0], true, nil

--- a/internal/access/node/conversation_facts_rpc.go
+++ b/internal/access/node/conversation_facts_rpc.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/WuKongIM/WuKongIM/pkg/channel"
+	channelruntime "github.com/WuKongIM/WuKongIM/pkg/channel/runtime"
 	raftcluster "github.com/WuKongIM/WuKongIM/pkg/cluster"
 )
 
@@ -213,7 +214,7 @@ func (a *Adapter) refreshConversationFactsMeta(ctx context.Context, id channel.C
 		return channel.Meta{}, channel.ErrStaleMeta
 	}
 	a.channelMeta.InvalidateChannelMeta(id)
-	return a.channelMeta.RefreshChannelMeta(ctx, id)
+	return a.channelMeta.ActivateByID(ctx, id, channelruntime.ActivationSourceFetch)
 }
 
 func loadLatestConversationMessageStrict(ctx context.Context, cluster ChannelLog, id channel.ChannelID, maxBytes int) (channel.Message, bool, error) {

--- a/internal/access/node/conversation_facts_rpc_test.go
+++ b/internal/access/node/conversation_facts_rpc_test.go
@@ -192,6 +192,34 @@ func TestConversationFactsRPCAuthoritativeLatestFencesEpochsAndRequiresLeader(t 
 	}}, log.fetches)
 }
 
+func TestLoadLatestConversationMessageAuthoritativeReturnsFirstConcurrentCommit(t *testing.T) {
+	log := &recordingAuthoritativeConversationFactsLog{
+		status: channel.ChannelRuntimeStatus{Leader: 1, LeaderEpoch: 12},
+		fetch: channel.FetchResult{
+			Messages: []channel.Message{{
+				ChannelID:   "g1",
+				ChannelType: 2,
+				MessageSeq:  1,
+			}},
+		},
+	}
+
+	msg, ok, err := LoadLatestConversationMessageAuthoritative(
+		context.Background(),
+		log,
+		channel.ChannelID{ID: "g1", Type: 2},
+		1024,
+		1,
+		11,
+		12,
+	)
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), msg.MessageSeq)
+	require.Equal(t, uint64(1), log.fetches[0].FromSeq)
+}
+
 func TestConversationFactsRPCAuthoritativeStaleCallerEpochDoesNotRefreshLocalMeta(t *testing.T) {
 	log := &recordingAuthoritativeConversationFactsLog{
 		status: channel.ChannelRuntimeStatus{Leader: 1, LeaderEpoch: 13, CommittedSeq: 7},
@@ -286,6 +314,23 @@ func TestConversationFactsAuthoritativeClientTreatsLegacyPeerCodecAsNotReady(t *
 		12,
 	)
 
+	require.ErrorIs(t, err, channel.ErrNotReady)
+	require.False(t, ok)
+}
+
+func TestConversationFactsAuthoritativeClientTreatsTransportFailureAsRouteUnavailable(t *testing.T) {
+	client := NewClient(remoteErrorCluster{err: errors.New("dial tcp 10.0.0.2:11110: connect: connection refused")})
+
+	_, ok, err := client.LoadLatestConversationMessageAuthoritative(
+		context.Background(),
+		2,
+		channel.ChannelID{ID: "g1", Type: 2},
+		1024,
+		11,
+		12,
+	)
+
+	require.ErrorIs(t, err, ErrConversationFactsRouteUnavailable)
 	require.ErrorIs(t, err, channel.ErrNotReady)
 	require.False(t, ok)
 }

--- a/internal/access/node/conversation_facts_rpc_test.go
+++ b/internal/access/node/conversation_facts_rpc_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/WuKongIM/WuKongIM/pkg/channel"
+	channelhandler "github.com/WuKongIM/WuKongIM/pkg/channel/handler"
 	channelruntime "github.com/WuKongIM/WuKongIM/pkg/channel/runtime"
+	channelstore "github.com/WuKongIM/WuKongIM/pkg/db/message"
 	"github.com/stretchr/testify/require"
 )
 
@@ -304,6 +306,51 @@ func TestConversationFactsAuthoritativeClientPreservesNotLeaderStatus(t *testing
 	require.False(t, ok)
 }
 
+func TestConversationFactsAuthoritativeClientPreservesPermanentChannelStatuses(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     channel.Status
+		wantStatus string
+		wantErr    error
+	}{
+		{name: "deleting", status: channel.StatusDeleting, wantStatus: conversationFactsStatusChannelDeleting, wantErr: channel.ErrChannelDeleting},
+		{name: "deleted", status: channel.StatusDeleted, wantStatus: conversationFactsStatusChannelNotFound, wantErr: channel.ErrChannelNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := newPermanentStatusConversationFactsLog(t, tt.status)
+			network := newFakeClusterNetwork(nil, nil)
+			adapter := New(Options{Cluster: network.cluster(2), ChannelLog: log, LocalNodeID: 2})
+			requestBody := mustEncodeConversationFactsRequest(t, conversationFactsRequest{
+				Op:                   conversationFactsOpLatestAuthoritative,
+				Key:                  newConversationFactsChannelKey(channel.ChannelID{ID: "g1", Type: 2}),
+				MaxBytes:             1024,
+				ExpectedChannelEpoch: 11,
+				ExpectedLeaderEpoch:  12,
+			})
+
+			responseBody, err := adapter.handleConversationFactsRPC(context.Background(), requestBody)
+			require.NoError(t, err)
+			response, err := decodeConversationFactsResponse(responseBody)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantStatus, response.Status)
+
+			client := NewClient(network.cluster(1))
+			_, ok, err := client.LoadLatestConversationMessageAuthoritative(
+				context.Background(),
+				2,
+				channel.ChannelID{ID: "g1", Type: 2},
+				1024,
+				11,
+				12,
+			)
+
+			require.ErrorIs(t, err, tt.wantErr)
+			require.False(t, ok)
+		})
+	}
+}
+
 func TestConversationFactsAuthoritativeClientTreatsLegacyPeerCodecAsNotReady(t *testing.T) {
 	client := NewClient(remoteErrorCluster{err: errors.New("nodetransport: remote error: access/node: invalid conversation facts request codec")})
 
@@ -321,7 +368,8 @@ func TestConversationFactsAuthoritativeClientTreatsLegacyPeerCodecAsNotReady(t *
 }
 
 func TestConversationFactsAuthoritativeClientTreatsTransportFailureAsRouteUnavailable(t *testing.T) {
-	client := NewClient(remoteErrorCluster{err: errors.New("dial tcp 10.0.0.2:11110: connect: connection refused")})
+	transportErr := errors.New("dial tcp 10.0.0.2:11110: connect: connection refused")
+	client := NewClient(remoteErrorCluster{err: transportErr})
 
 	_, ok, err := client.LoadLatestConversationMessageAuthoritative(
 		context.Background(),
@@ -334,6 +382,7 @@ func TestConversationFactsAuthoritativeClientTreatsTransportFailureAsRouteUnavai
 
 	require.ErrorIs(t, err, ErrConversationFactsRouteUnavailable)
 	require.ErrorIs(t, err, channel.ErrNotReady)
+	require.ErrorIs(t, err, transportErr)
 	require.False(t, ok)
 }
 
@@ -427,6 +476,57 @@ type recordingAuthoritativeConversationFactsLog struct {
 	fetch     channel.FetchResult
 	fetchErr  error
 	fetches   []channel.FetchRequest
+}
+
+type permanentStatusConversationFactsLog struct {
+	channel.MetaRollbackService
+	status channel.ChannelRuntimeStatus
+}
+
+func (l permanentStatusConversationFactsLog) Status(channel.ChannelID) (channel.ChannelRuntimeStatus, error) {
+	return l.status, nil
+}
+
+type emptyConversationFactsHandlerRuntime struct{}
+
+func (emptyConversationFactsHandlerRuntime) Channel(channel.ChannelKey) (channel.HandlerChannel, bool) {
+	return nil, false
+}
+
+type conversationFactsMessageIDs struct{}
+
+func (conversationFactsMessageIDs) Next() uint64 { return 1 }
+
+func newPermanentStatusConversationFactsLog(t *testing.T, status channel.Status) ChannelLog {
+	t.Helper()
+
+	engine, err := channelstore.Open(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, engine.Close()) })
+
+	service, err := channelhandler.New(channelhandler.Config{
+		Runtime:    emptyConversationFactsHandlerRuntime{},
+		Store:      engine,
+		MessageIDs: conversationFactsMessageIDs{},
+	})
+	require.NoError(t, err)
+	id := channel.ChannelID{ID: "g1", Type: 2}
+	require.NoError(t, service.ApplyMeta(channel.Meta{
+		ID:          id,
+		Epoch:       11,
+		LeaderEpoch: 12,
+		Leader:      2,
+		Status:      status,
+	}))
+
+	return permanentStatusConversationFactsLog{
+		MetaRollbackService: service,
+		status: channel.ChannelRuntimeStatus{
+			Leader:       2,
+			LeaderEpoch:  12,
+			CommittedSeq: 7,
+		},
+	}
 }
 
 func (l *recordingAuthoritativeConversationFactsLog) Status(channel.ChannelID) (channel.ChannelRuntimeStatus, error) {

--- a/internal/access/node/conversation_facts_rpc_test.go
+++ b/internal/access/node/conversation_facts_rpc_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/WuKongIM/WuKongIM/pkg/channel"
@@ -157,11 +158,12 @@ func TestConversationFactsRPCAuthoritativeLatestRejectsFollower(t *testing.T) {
 func TestConversationFactsRPCAuthoritativeLatestFencesEpochsAndRequiresLeader(t *testing.T) {
 	log := &recordingAuthoritativeConversationFactsLog{
 		status: channel.ChannelRuntimeStatus{Leader: 1, LeaderEpoch: 12, CommittedSeq: 7},
-		fetch: channel.FetchResult{Messages: []channel.Message{{
-			ChannelID:   "g1",
-			ChannelType: 2,
-			MessageSeq:  7,
-		}},
+		fetch: channel.FetchResult{
+			Messages: []channel.Message{{
+				ChannelID:   "g1",
+				ChannelType: 2,
+				MessageSeq:  7,
+			}},
 		},
 	}
 	adapter := New(Options{ChannelLog: log, LocalNodeID: 1})
@@ -190,6 +192,66 @@ func TestConversationFactsRPCAuthoritativeLatestFencesEpochsAndRequiresLeader(t 
 	}}, log.fetches)
 }
 
+func TestConversationFactsRPCAuthoritativeStaleCallerEpochDoesNotRefreshLocalMeta(t *testing.T) {
+	log := &recordingAuthoritativeConversationFactsLog{
+		status: channel.ChannelRuntimeStatus{Leader: 1, LeaderEpoch: 13, CommittedSeq: 7},
+	}
+	refresher := &refreshingConversationFactsMetaRefresher{}
+	adapter := New(Options{ChannelLog: log, ChannelMeta: refresher, LocalNodeID: 1})
+	body := mustEncodeConversationFactsRequest(t, conversationFactsRequest{
+		Op:                   conversationFactsOpLatestAuthoritative,
+		Key:                  newConversationFactsChannelKey(channel.ChannelID{ID: "g1", Type: 2}),
+		MaxBytes:             1024,
+		ExpectedChannelEpoch: 11,
+		ExpectedLeaderEpoch:  12,
+	})
+
+	respBody, err := adapter.handleConversationFactsRPC(context.Background(), body)
+	require.NoError(t, err)
+	resp, err := decodeConversationFactsResponse(respBody)
+	require.NoError(t, err)
+	require.Equal(t, conversationFactsStatusStaleMeta, resp.Status)
+	require.Empty(t, refresher.calls)
+	require.Empty(t, refresher.invalidations)
+	require.Empty(t, log.fetches)
+}
+
+func TestConversationFactsRPCAuthoritativeRefreshesMissingLocalRuntime(t *testing.T) {
+	log := &refreshableConversationFactsLog{
+		status: channel.ChannelRuntimeStatus{Leader: 1, LeaderEpoch: 12, CommittedSeq: 7},
+		fetch: channel.FetchResult{
+			Messages: []channel.Message{{
+				ChannelID:   "g1",
+				ChannelType: 2,
+				MessageSeq:  7,
+			}},
+		},
+	}
+	refresher := &refreshingConversationFactsMetaRefresher{
+		meta: channel.Meta{ID: channel.ChannelID{ID: "g1", Type: 2}, Epoch: 11, LeaderEpoch: 12, Leader: 1},
+		onRefresh: func() {
+			log.markRefreshed()
+		},
+	}
+	adapter := New(Options{ChannelLog: log, ChannelMeta: refresher, LocalNodeID: 1})
+	body := mustEncodeConversationFactsRequest(t, conversationFactsRequest{
+		Op:                   conversationFactsOpLatestAuthoritative,
+		Key:                  newConversationFactsChannelKey(channel.ChannelID{ID: "g1", Type: 2}),
+		MaxBytes:             1024,
+		ExpectedChannelEpoch: 11,
+		ExpectedLeaderEpoch:  12,
+	})
+
+	respBody, err := adapter.handleConversationFactsRPC(context.Background(), body)
+	require.NoError(t, err)
+	resp, err := decodeConversationFactsResponse(respBody)
+	require.NoError(t, err)
+	require.Equal(t, rpcStatusOK, resp.Status)
+	require.Len(t, resp.Messages, 1)
+	require.Equal(t, []channel.ChannelID{{ID: "g1", Type: 2}}, refresher.invalidations)
+	require.Equal(t, []channel.ChannelID{{ID: "g1", Type: 2}}, refresher.calls)
+}
+
 func TestConversationFactsAuthoritativeClientPreservesNotLeaderStatus(t *testing.T) {
 	network := newFakeClusterNetwork(nil, nil)
 	New(Options{
@@ -209,6 +271,41 @@ func TestConversationFactsAuthoritativeClientPreservesNotLeaderStatus(t *testing
 	)
 
 	require.ErrorIs(t, err, channel.ErrNotLeader)
+	require.False(t, ok)
+}
+
+func TestConversationFactsAuthoritativeClientTreatsLegacyPeerCodecAsNotReady(t *testing.T) {
+	client := NewClient(remoteErrorCluster{err: errors.New("nodetransport: remote error: access/node: invalid conversation facts request codec")})
+
+	_, ok, err := client.LoadLatestConversationMessageAuthoritative(
+		context.Background(),
+		2,
+		channel.ChannelID{ID: "g1", Type: 2},
+		1024,
+		11,
+		12,
+	)
+
+	require.ErrorIs(t, err, channel.ErrNotReady)
+	require.False(t, ok)
+}
+
+func TestConversationFactsOrdinaryClientPreservesStaleMetaStatus(t *testing.T) {
+	network := newFakeClusterNetwork(nil, nil)
+	New(Options{
+		Cluster:    network.cluster(2),
+		ChannelLog: &recordingAuthoritativeConversationFactsLog{statusErr: channel.ErrStaleMeta},
+	})
+	client := NewClient(network.cluster(1))
+
+	_, ok, err := client.LoadLatestConversationMessage(
+		context.Background(),
+		2,
+		channel.ChannelID{ID: "g1", Type: 2},
+		1024,
+	)
+
+	require.ErrorIs(t, err, channel.ErrStaleMeta)
 	require.False(t, ok)
 }
 
@@ -247,6 +344,7 @@ func TestConversationFactsRPCRefreshesStaleMetaForBatchRecentLoads(t *testing.T)
 	resp, err := decodeConversationFactsResponse(respBody)
 	require.NoError(t, err)
 	require.Equal(t, []channel.ChannelID{{ID: "g1", Type: 2}}, refresher.calls)
+	require.Equal(t, []channel.ChannelID{{ID: "g1", Type: 2}}, refresher.invalidations)
 	require.Len(t, resp.Entries, 1)
 	require.Len(t, resp.Entries[0].Messages, 1)
 	require.Equal(t, uint64(7), resp.Entries[0].Messages[0].MessageSeq)
@@ -328,10 +426,11 @@ func (l *refreshableConversationFactsLog) markRefreshed() {
 }
 
 type refreshingConversationFactsMetaRefresher struct {
-	meta      channel.Meta
-	err       error
-	calls     []channel.ChannelID
-	onRefresh func()
+	meta          channel.Meta
+	err           error
+	calls         []channel.ChannelID
+	invalidations []channel.ChannelID
+	onRefresh     func()
 }
 
 func (r *refreshingConversationFactsMetaRefresher) RefreshChannelMeta(_ context.Context, id channel.ChannelID) (channel.Meta, error) {
@@ -340,6 +439,10 @@ func (r *refreshingConversationFactsMetaRefresher) RefreshChannelMeta(_ context.
 		r.onRefresh()
 	}
 	return r.meta, r.err
+}
+
+func (r *refreshingConversationFactsMetaRefresher) InvalidateChannelMeta(id channel.ChannelID) {
+	r.invalidations = append(r.invalidations, id)
 }
 
 func mustEncodeConversationFactsRequest(t *testing.T, req conversationFactsRequest) []byte {

--- a/internal/access/node/conversation_facts_rpc_test.go
+++ b/internal/access/node/conversation_facts_rpc_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/WuKongIM/WuKongIM/pkg/channel"
+	channelruntime "github.com/WuKongIM/WuKongIM/pkg/channel/runtime"
 	"github.com/stretchr/testify/require"
 )
 
@@ -278,6 +279,7 @@ func TestConversationFactsRPCAuthoritativeRefreshesMissingLocalRuntime(t *testin
 	require.Len(t, resp.Messages, 1)
 	require.Equal(t, []channel.ChannelID{{ID: "g1", Type: 2}}, refresher.invalidations)
 	require.Equal(t, []channel.ChannelID{{ID: "g1", Type: 2}}, refresher.calls)
+	require.Equal(t, []channelruntime.ActivationSource{channelruntime.ActivationSourceFetch}, refresher.activationSources)
 }
 
 func TestConversationFactsAuthoritativeClientPreservesNotLeaderStatus(t *testing.T) {
@@ -471,11 +473,21 @@ func (l *refreshableConversationFactsLog) markRefreshed() {
 }
 
 type refreshingConversationFactsMetaRefresher struct {
-	meta          channel.Meta
-	err           error
-	calls         []channel.ChannelID
-	invalidations []channel.ChannelID
-	onRefresh     func()
+	meta              channel.Meta
+	err               error
+	calls             []channel.ChannelID
+	invalidations     []channel.ChannelID
+	activationSources []channelruntime.ActivationSource
+	onRefresh         func()
+}
+
+func (r *refreshingConversationFactsMetaRefresher) ActivateByID(_ context.Context, id channel.ChannelID, source channelruntime.ActivationSource) (channel.Meta, error) {
+	r.activationSources = append(r.activationSources, source)
+	r.calls = append(r.calls, id)
+	if r.onRefresh != nil {
+		r.onRefresh()
+	}
+	return r.meta, r.err
 }
 
 func (r *refreshingConversationFactsMetaRefresher) RefreshChannelMeta(_ context.Context, id channel.ChannelID) (channel.Meta, error) {

--- a/internal/access/node/conversation_facts_rpc_test.go
+++ b/internal/access/node/conversation_facts_rpc_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestConversationFactsBinaryCodecRoundTrip(t *testing.T) {
 	req := conversationFactsRequest{
-		Op: conversationFactsOpLatest,
+		Op: conversationFactsOpLatestAuthoritative,
 		Key: newConversationFactsChannelKey(channel.ChannelID{
 			ID:   "g1",
 			Type: 2,
@@ -19,8 +19,10 @@ func TestConversationFactsBinaryCodecRoundTrip(t *testing.T) {
 			newConversationFactsChannelKey(channel.ChannelID{ID: "g1", Type: 2}),
 			newConversationFactsChannelKey(channel.ChannelID{ID: "g2", Type: 3}),
 		},
-		Limit:    5,
-		MaxBytes: 1024,
+		Limit:                5,
+		MaxBytes:             1024,
+		ExpectedChannelEpoch: 11,
+		ExpectedLeaderEpoch:  12,
 	}
 	reqBody, err := encodeConversationFactsRequestBinary(req)
 	require.NoError(t, err)
@@ -64,17 +66,150 @@ func TestConversationFactsRPCRejectsJSONPayload(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestLoadLatestConversationMessageReturnsNotReady(t *testing.T) {
-	msg, ok, err := loadLatestConversationMessage(context.Background(), notReadyConversationFactsLog{}, channel.ChannelID{ID: "g1", Type: 2}, 1024)
+func TestLoadLatestConversationMessageStrictReturnsNotReady(t *testing.T) {
+	msg, ok, err := loadLatestConversationMessageStrict(context.Background(), notReadyConversationFactsLog{}, channel.ChannelID{ID: "g1", Type: 2}, 1024)
 	require.ErrorIs(t, err, channel.ErrNotReady)
 	require.False(t, ok)
 	require.Equal(t, channel.Message{}, msg)
 }
 
-func TestLoadRecentConversationMessagesReturnsNotReady(t *testing.T) {
-	msgs, err := loadRecentConversationMessages(context.Background(), notReadyConversationFactsLog{}, channel.ChannelID{ID: "g1", Type: 2}, 10, 1024)
+func TestLoadRecentConversationMessagesStrictReturnsNotReady(t *testing.T) {
+	msgs, err := loadRecentConversationMessagesStrict(context.Background(), notReadyConversationFactsLog{}, channel.ChannelID{ID: "g1", Type: 2}, 10, 1024)
 	require.ErrorIs(t, err, channel.ErrNotReady)
 	require.Nil(t, msgs)
+}
+
+func TestConversationFactsRPCOrdinaryLatestKeepsNotReadyAsEmpty(t *testing.T) {
+	adapter := New(Options{ChannelLog: notReadyConversationFactsLog{}})
+	body := mustEncodeConversationFactsRequest(t, conversationFactsRequest{
+		Op:       conversationFactsOpLatest,
+		Key:      newConversationFactsChannelKey(channel.ChannelID{ID: "g1", Type: 2}),
+		MaxBytes: 1024,
+	})
+
+	respBody, err := adapter.handleConversationFactsRPC(context.Background(), body)
+	require.NoError(t, err)
+	resp, err := decodeConversationFactsResponse(respBody)
+	require.NoError(t, err)
+	require.Equal(t, rpcStatusOK, resp.Status)
+	require.Empty(t, resp.Messages)
+}
+
+func TestConversationFactsRPCOrdinaryBatchDoesNotFailOnNotReadyChannel(t *testing.T) {
+	adapter := New(Options{ChannelLog: notReadyConversationFactsLog{}})
+	body := mustEncodeConversationFactsRequest(t, conversationFactsRequest{
+		Op: conversationFactsOpLatest,
+		Keys: []conversationFactsChannelKey{
+			newConversationFactsChannelKey(channel.ChannelID{ID: "g1", Type: 2}),
+			newConversationFactsChannelKey(channel.ChannelID{ID: "g2", Type: 2}),
+		},
+		MaxBytes: 1024,
+	})
+
+	respBody, err := adapter.handleConversationFactsRPC(context.Background(), body)
+	require.NoError(t, err)
+	resp, err := decodeConversationFactsResponse(respBody)
+	require.NoError(t, err)
+	require.Equal(t, rpcStatusOK, resp.Status)
+	require.Len(t, resp.Entries, 2)
+	require.Empty(t, resp.Entries[0].Messages)
+	require.Empty(t, resp.Entries[1].Messages)
+}
+
+func TestConversationFactsRPCAuthoritativeLatestReturnsNotReadyStatus(t *testing.T) {
+	adapter := New(Options{ChannelLog: notReadyConversationFactsLog{}, LocalNodeID: 1})
+	body := mustEncodeConversationFactsRequest(t, conversationFactsRequest{
+		Op:                   conversationFactsOpLatestAuthoritative,
+		Key:                  newConversationFactsChannelKey(channel.ChannelID{ID: "g1", Type: 2}),
+		MaxBytes:             1024,
+		ExpectedChannelEpoch: 11,
+		ExpectedLeaderEpoch:  12,
+	})
+
+	respBody, err := adapter.handleConversationFactsRPC(context.Background(), body)
+	require.NoError(t, err)
+	resp, err := decodeConversationFactsResponse(respBody)
+	require.NoError(t, err)
+	require.Equal(t, conversationFactsStatusNotReady, resp.Status)
+}
+
+func TestConversationFactsRPCAuthoritativeLatestRejectsFollower(t *testing.T) {
+	log := &recordingAuthoritativeConversationFactsLog{
+		status: channel.ChannelRuntimeStatus{Leader: 2, LeaderEpoch: 12, CommittedSeq: 7},
+	}
+	adapter := New(Options{ChannelLog: log, LocalNodeID: 1})
+	body := mustEncodeConversationFactsRequest(t, conversationFactsRequest{
+		Op:                   conversationFactsOpLatestAuthoritative,
+		Key:                  newConversationFactsChannelKey(channel.ChannelID{ID: "g1", Type: 2}),
+		MaxBytes:             1024,
+		ExpectedChannelEpoch: 11,
+		ExpectedLeaderEpoch:  12,
+	})
+
+	respBody, err := adapter.handleConversationFactsRPC(context.Background(), body)
+	require.NoError(t, err)
+	resp, err := decodeConversationFactsResponse(respBody)
+	require.NoError(t, err)
+	require.Equal(t, rpcStatusNotLeader, resp.Status)
+	require.Empty(t, log.fetches)
+}
+
+func TestConversationFactsRPCAuthoritativeLatestFencesEpochsAndRequiresLeader(t *testing.T) {
+	log := &recordingAuthoritativeConversationFactsLog{
+		status: channel.ChannelRuntimeStatus{Leader: 1, LeaderEpoch: 12, CommittedSeq: 7},
+		fetch: channel.FetchResult{Messages: []channel.Message{{
+			ChannelID:   "g1",
+			ChannelType: 2,
+			MessageSeq:  7,
+		}},
+		},
+	}
+	adapter := New(Options{ChannelLog: log, LocalNodeID: 1})
+	body := mustEncodeConversationFactsRequest(t, conversationFactsRequest{
+		Op:                   conversationFactsOpLatestAuthoritative,
+		Key:                  newConversationFactsChannelKey(channel.ChannelID{ID: "g1", Type: 2}),
+		MaxBytes:             1024,
+		ExpectedChannelEpoch: 11,
+		ExpectedLeaderEpoch:  12,
+	})
+
+	respBody, err := adapter.handleConversationFactsRPC(context.Background(), body)
+	require.NoError(t, err)
+	resp, err := decodeConversationFactsResponse(respBody)
+	require.NoError(t, err)
+	require.Equal(t, rpcStatusOK, resp.Status)
+	require.Len(t, resp.Messages, 1)
+	require.Equal(t, []channel.FetchRequest{{
+		ChannelID:            channel.ChannelID{ID: "g1", Type: 2},
+		FromSeq:              7,
+		Limit:                1,
+		MaxBytes:             1024,
+		ExpectedChannelEpoch: 11,
+		ExpectedLeaderEpoch:  12,
+		RequireLeader:        true,
+	}}, log.fetches)
+}
+
+func TestConversationFactsAuthoritativeClientPreservesNotLeaderStatus(t *testing.T) {
+	network := newFakeClusterNetwork(nil, nil)
+	New(Options{
+		Cluster:     network.cluster(2),
+		ChannelLog:  &recordingAuthoritativeConversationFactsLog{status: channel.ChannelRuntimeStatus{Leader: 3, LeaderEpoch: 12, CommittedSeq: 7}},
+		LocalNodeID: 2,
+	})
+	client := NewClient(network.cluster(1))
+
+	_, ok, err := client.LoadLatestConversationMessageAuthoritative(
+		context.Background(),
+		2,
+		channel.ChannelID{ID: "g1", Type: 2},
+		1024,
+		11,
+		12,
+	)
+
+	require.ErrorIs(t, err, channel.ErrNotLeader)
+	require.False(t, ok)
 }
 
 func TestConversationFactsRPCRefreshesStaleMetaForBatchRecentLoads(t *testing.T) {
@@ -139,6 +274,31 @@ type refreshableConversationFactsLog struct {
 	status    channel.ChannelRuntimeStatus
 	fetch     channel.FetchResult
 	refreshed bool
+}
+
+type recordingAuthoritativeConversationFactsLog struct {
+	status    channel.ChannelRuntimeStatus
+	statusErr error
+	fetch     channel.FetchResult
+	fetchErr  error
+	fetches   []channel.FetchRequest
+}
+
+func (l *recordingAuthoritativeConversationFactsLog) Status(channel.ChannelID) (channel.ChannelRuntimeStatus, error) {
+	return l.status, l.statusErr
+}
+
+func (l *recordingAuthoritativeConversationFactsLog) Fetch(_ context.Context, req channel.FetchRequest) (channel.FetchResult, error) {
+	l.fetches = append(l.fetches, req)
+	return l.fetch, l.fetchErr
+}
+
+func (l *recordingAuthoritativeConversationFactsLog) Append(context.Context, channel.AppendRequest) (channel.AppendResult, error) {
+	return channel.AppendResult{}, nil
+}
+
+func (l *recordingAuthoritativeConversationFactsLog) AppendBatch(context.Context, channel.AppendBatchRequest) (channel.AppendBatchResult, error) {
+	return channel.AppendBatchResult{}, nil
 }
 
 func (l *refreshableConversationFactsLog) Status(channel.ChannelID) (channel.ChannelRuntimeStatus, error) {

--- a/internal/access/node/conversation_facts_rpc_test.go
+++ b/internal/access/node/conversation_facts_rpc_test.go
@@ -64,16 +64,16 @@ func TestConversationFactsRPCRejectsJSONPayload(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestLoadLatestConversationMessageTreatsNotReadyAsEmpty(t *testing.T) {
+func TestLoadLatestConversationMessageReturnsNotReady(t *testing.T) {
 	msg, ok, err := loadLatestConversationMessage(context.Background(), notReadyConversationFactsLog{}, channel.ChannelID{ID: "g1", Type: 2}, 1024)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, channel.ErrNotReady)
 	require.False(t, ok)
 	require.Equal(t, channel.Message{}, msg)
 }
 
-func TestLoadRecentConversationMessagesTreatsNotReadyAsEmpty(t *testing.T) {
+func TestLoadRecentConversationMessagesReturnsNotReady(t *testing.T) {
 	msgs, err := loadRecentConversationMessages(context.Background(), notReadyConversationFactsLog{}, channel.ChannelID{ID: "g1", Type: 2}, 10, 1024)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, channel.ErrNotReady)
 	require.Nil(t, msgs)
 }
 

--- a/internal/access/node/options.go
+++ b/internal/access/node/options.go
@@ -17,6 +17,7 @@ import (
 	"github.com/WuKongIM/WuKongIM/internal/usecase/plugin/pluginproto"
 	"github.com/WuKongIM/WuKongIM/internal/usecase/presence"
 	"github.com/WuKongIM/WuKongIM/pkg/channel"
+	channelruntime "github.com/WuKongIM/WuKongIM/pkg/channel/runtime"
 	raftcluster "github.com/WuKongIM/WuKongIM/pkg/cluster"
 	channelstore "github.com/WuKongIM/WuKongIM/pkg/db/message"
 	"github.com/WuKongIM/WuKongIM/pkg/metrics"
@@ -53,6 +54,7 @@ type ChannelLog interface {
 
 type ChannelMetaRefresher interface {
 	RefreshChannelMeta(ctx context.Context, id channel.ChannelID) (channel.Meta, error)
+	ActivateByID(ctx context.Context, id channel.ChannelID, source channelruntime.ActivationSource) (channel.Meta, error)
 	InvalidateChannelMeta(id channel.ChannelID)
 }
 

--- a/internal/access/node/options.go
+++ b/internal/access/node/options.go
@@ -53,6 +53,7 @@ type ChannelLog interface {
 
 type ChannelMetaRefresher interface {
 	RefreshChannelMeta(ctx context.Context, id channel.ChannelID) (channel.Meta, error)
+	InvalidateChannelMeta(id channel.ChannelID)
 }
 
 // ChannelLeaderRepairer repairs a channel leader on the authoritative slot leader.

--- a/internal/app/build.go
+++ b/internal/app/build.go
@@ -1303,7 +1303,10 @@ func (c ClusterConfig) runtimeSeeds() []raftcluster.SeedConfig {
 	return seeds
 }
 
-const conversationFetchMaxBytes = 1 << 20
+const (
+	conversationFetchMaxBytes      = 1 << 20
+	conversationFactsRouteAttempts = 2
+)
 
 type channelLogConversationFacts struct {
 	cluster interface {
@@ -1319,7 +1322,7 @@ type channelLogConversationFacts struct {
 		LoadRecentConversationMessages(ctx context.Context, nodeID uint64, key channel.ChannelID, limit, maxBytes int) ([]channel.Message, error)
 	}
 	metaRefresh interface {
-		RefreshChannelMeta(ctx context.Context, id channel.ChannelID) (channel.Meta, error)
+		ActivateByID(ctx context.Context, id channel.ChannelID, source channelruntime.ActivationSource) (channel.Meta, error)
 		InvalidateChannelMeta(id channel.ChannelID)
 	}
 	localNodeID uint64
@@ -1398,12 +1401,15 @@ func (f channelLogConversationFacts) loadLatestMessageAuthoritative(ctx context.
 		return channel.Message{}, false, channel.ErrStaleMeta
 	}
 	var lastErr error
-	for attempt := 0; attempt < 2; attempt++ {
-		meta, err := f.metaRefresh.RefreshChannelMeta(ctx, id)
+	for attempt := 0; attempt < conversationFactsRouteAttempts; attempt++ {
+		meta, err := f.metaRefresh.ActivateByID(ctx, id, channelruntime.ActivationSourceFetch)
 		if err != nil {
+			if errors.Is(err, metadb.ErrNotFound) {
+				return channel.Message{}, false, channel.ErrChannelNotFound
+			}
 			lastErr = err
 			if conversationFactsRouteRetryable(lastErr) {
-				if attempt == 0 {
+				if attempt+1 < conversationFactsRouteAttempts {
 					f.metaRefresh.InvalidateChannelMeta(id)
 				}
 				continue
@@ -1419,7 +1425,7 @@ func (f channelLogConversationFacts) loadLatestMessageAuthoritative(ctx context.
 		if meta.Leader == 0 {
 			lastErr = raftcluster.ErrNoLeader
 		} else if uint64(meta.Leader) == f.localNodeID {
-			msg, ok, loadErr = loadLatestConversationMessageAuthoritative(ctx, f.cluster, id, conversationFetchMaxBytes, f.localNodeID, meta.Epoch, meta.LeaderEpoch)
+			msg, ok, loadErr = accessnode.LoadLatestConversationMessageAuthoritative(ctx, f.cluster, id, conversationFetchMaxBytes, f.localNodeID, meta.Epoch, meta.LeaderEpoch)
 		} else if f.remote == nil {
 			return channel.Message{}, false, channel.ErrStaleMeta
 		} else {
@@ -1441,7 +1447,7 @@ func (f channelLogConversationFacts) loadLatestMessageAuthoritative(ctx context.
 		if !conversationFactsRouteRetryable(lastErr) {
 			return channel.Message{}, false, lastErr
 		}
-		if attempt == 0 {
+		if attempt+1 < conversationFactsRouteAttempts {
 			f.metaRefresh.InvalidateChannelMeta(id)
 		}
 	}
@@ -1451,6 +1457,7 @@ func (f channelLogConversationFacts) loadLatestMessageAuthoritative(ctx context.
 func conversationFactsRouteRetryable(err error) bool {
 	return errors.Is(err, channel.ErrNotLeader) ||
 		errors.Is(err, channel.ErrStaleMeta) ||
+		errors.Is(err, accessnode.ErrConversationFactsRouteUnavailable) ||
 		errors.Is(err, raftcluster.ErrNoLeader)
 }
 
@@ -1660,49 +1667,6 @@ func loadLatestConversationMessage(ctx context.Context, cluster interface {
 		return channel.Message{}, false, err
 	}
 	if len(fetch.Messages) == 0 {
-		return channel.Message{}, false, nil
-	}
-	return fetch.Messages[0], true, nil
-}
-
-func loadLatestConversationMessageAuthoritative(ctx context.Context, cluster interface {
-	Status(id channel.ChannelID) (channel.ChannelRuntimeStatus, error)
-	Fetch(ctx context.Context, req channel.FetchRequest) (channel.FetchResult, error)
-}, key channel.ChannelID, maxBytes int, localNodeID, expectedChannelEpoch, expectedLeaderEpoch uint64) (channel.Message, bool, error) {
-	if cluster == nil || localNodeID == 0 {
-		return channel.Message{}, false, channel.ErrStaleMeta
-	}
-	status, err := cluster.Status(key)
-	if err != nil {
-		return channel.Message{}, false, err
-	}
-	if status.Leader == 0 {
-		return channel.Message{}, false, raftcluster.ErrNoLeader
-	}
-	if uint64(status.Leader) != localNodeID {
-		return channel.Message{}, false, channel.ErrNotLeader
-	}
-	if expectedLeaderEpoch != 0 && status.LeaderEpoch != expectedLeaderEpoch {
-		return channel.Message{}, false, channel.ErrStaleMeta
-	}
-
-	fromSeq := status.CommittedSeq
-	if fromSeq == 0 {
-		fromSeq = 1
-	}
-	fetch, err := cluster.Fetch(ctx, channel.FetchRequest{
-		ChannelID:            key,
-		FromSeq:              fromSeq,
-		Limit:                1,
-		MaxBytes:             maxBytes,
-		ExpectedChannelEpoch: expectedChannelEpoch,
-		ExpectedLeaderEpoch:  expectedLeaderEpoch,
-		RequireLeader:        true,
-	})
-	if err != nil {
-		return channel.Message{}, false, err
-	}
-	if status.CommittedSeq == 0 || len(fetch.Messages) == 0 {
 		return channel.Message{}, false, nil
 	}
 	return fetch.Messages[0], true, nil

--- a/internal/app/build.go
+++ b/internal/app/build.go
@@ -1320,6 +1320,7 @@ type channelLogConversationFacts struct {
 	}
 	metaRefresh interface {
 		RefreshChannelMeta(ctx context.Context, id channel.ChannelID) (channel.Meta, error)
+		InvalidateChannelMeta(id channel.ChannelID)
 	}
 	localNodeID uint64
 }
@@ -1402,6 +1403,9 @@ func (f channelLogConversationFacts) loadLatestMessageAuthoritative(ctx context.
 		if err != nil {
 			lastErr = err
 			if conversationFactsRouteRetryable(lastErr) {
+				if attempt == 0 {
+					f.metaRefresh.InvalidateChannelMeta(id)
+				}
 				continue
 			}
 			return channel.Message{}, false, lastErr
@@ -1436,6 +1440,9 @@ func (f channelLogConversationFacts) loadLatestMessageAuthoritative(ctx context.
 		}
 		if !conversationFactsRouteRetryable(lastErr) {
 			return channel.Message{}, false, lastErr
+		}
+		if attempt == 0 {
+			f.metaRefresh.InvalidateChannelMeta(id)
 		}
 	}
 	return channel.Message{}, false, lastErr

--- a/internal/app/build.go
+++ b/internal/app/build.go
@@ -532,13 +532,17 @@ func build(cfg Config) (_ *App, err error) {
 		GroupActiveFanoutMaxSubscribers: cfg.Conversation.GroupActiveFanoutMaxSubscribers,
 		Logger:                          app.logger.Named("conversation.projector"),
 	})
+	conversationFacts := channelLogConversationFacts{
+		cluster:     app.channelLog,
+		metas:       app.store,
+		remote:      app.nodeClient,
+		metaRefresh: app.channelMetaSync,
+		localNodeID: cfg.Node.ID,
+	}
 	app.conversationApp = conversationusecase.New(conversationusecase.Options{
-		States: app.store,
-		Facts: channelLogConversationFacts{
-			cluster: app.channelLog,
-			metas:   app.store,
-			remote:  app.nodeClient,
-		},
+		States:                app.store,
+		Facts:                 conversationFacts,
+		AuthoritativeFacts:    conversationFacts,
 		Now:                   time.Now,
 		ColdThreshold:         cfg.Conversation.ColdThreshold,
 		ActiveScanLimit:       cfg.Conversation.ActiveScanLimit,
@@ -1311,8 +1315,13 @@ type channelLogConversationFacts struct {
 	}
 	remote interface {
 		LoadLatestConversationMessage(ctx context.Context, nodeID uint64, key channel.ChannelID, maxBytes int) (channel.Message, bool, error)
+		LoadLatestConversationMessageAuthoritative(ctx context.Context, nodeID uint64, key channel.ChannelID, maxBytes int, expectedChannelEpoch, expectedLeaderEpoch uint64) (channel.Message, bool, error)
 		LoadRecentConversationMessages(ctx context.Context, nodeID uint64, key channel.ChannelID, limit, maxBytes int) ([]channel.Message, error)
 	}
+	metaRefresh interface {
+		RefreshChannelMeta(ctx context.Context, id channel.ChannelID) (channel.Meta, error)
+	}
+	localNodeID uint64
 }
 
 type batchConversationFactsRemote interface {
@@ -1370,15 +1379,9 @@ func (f channelLogConversationFacts) LoadLatestMessages(ctx context.Context, key
 // before loading its latest message. Conversation mutations use this path so a
 // readable but lagging local replica cannot produce a stale read cursor.
 func (f channelLogConversationFacts) LoadLatestMessagesAuthoritative(ctx context.Context, keys []conversationusecase.ConversationKey) (map[conversationusecase.ConversationKey]channel.Message, error) {
-	if len(keys) == 0 {
-		return map[conversationusecase.ConversationKey]channel.Message{}, nil
-	}
-	if remote, ok := f.remote.(batchConversationFactsRemote); ok {
-		return f.loadRemoteLatestMessagesBatch(ctx, remote, keys)
-	}
 	out := make(map[conversationusecase.ConversationKey]channel.Message, len(keys))
 	for _, key := range keys {
-		msg, ok, err := f.loadRemoteLatestMessage(ctx, channel.ChannelID{ID: key.ChannelID, Type: key.ChannelType})
+		msg, ok, err := f.loadLatestMessageAuthoritative(ctx, channel.ChannelID{ID: key.ChannelID, Type: key.ChannelType})
 		if err != nil {
 			return nil, err
 		}
@@ -1387,6 +1390,61 @@ func (f channelLogConversationFacts) LoadLatestMessagesAuthoritative(ctx context
 		}
 	}
 	return out, nil
+}
+
+func (f channelLogConversationFacts) loadLatestMessageAuthoritative(ctx context.Context, id channel.ChannelID) (channel.Message, bool, error) {
+	if f.metaRefresh == nil {
+		return channel.Message{}, false, channel.ErrStaleMeta
+	}
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		meta, err := f.metaRefresh.RefreshChannelMeta(ctx, id)
+		if err != nil {
+			lastErr = err
+			if conversationFactsRouteRetryable(lastErr) {
+				continue
+			}
+			return channel.Message{}, false, lastErr
+		}
+
+		var (
+			msg     channel.Message
+			ok      bool
+			loadErr error
+		)
+		if meta.Leader == 0 {
+			lastErr = raftcluster.ErrNoLeader
+		} else if uint64(meta.Leader) == f.localNodeID {
+			msg, ok, loadErr = loadLatestConversationMessageAuthoritative(ctx, f.cluster, id, conversationFetchMaxBytes, f.localNodeID, meta.Epoch, meta.LeaderEpoch)
+		} else if f.remote == nil {
+			return channel.Message{}, false, channel.ErrStaleMeta
+		} else {
+			msg, ok, loadErr = f.remote.LoadLatestConversationMessageAuthoritative(
+				ctx,
+				uint64(meta.Leader),
+				id,
+				conversationFetchMaxBytes,
+				meta.Epoch,
+				meta.LeaderEpoch,
+			)
+		}
+		if loadErr == nil && meta.Leader != 0 {
+			return msg, ok, nil
+		}
+		if loadErr != nil {
+			lastErr = loadErr
+		}
+		if !conversationFactsRouteRetryable(lastErr) {
+			return channel.Message{}, false, lastErr
+		}
+	}
+	return channel.Message{}, false, lastErr
+}
+
+func conversationFactsRouteRetryable(err error) bool {
+	return errors.Is(err, channel.ErrNotLeader) ||
+		errors.Is(err, channel.ErrStaleMeta) ||
+		errors.Is(err, raftcluster.ErrNoLeader)
 }
 
 func (f channelLogConversationFacts) LoadRecentMessages(ctx context.Context, key conversationusecase.ConversationKey, limit int) ([]channel.Message, error) {
@@ -1595,6 +1653,49 @@ func loadLatestConversationMessage(ctx context.Context, cluster interface {
 		return channel.Message{}, false, err
 	}
 	if len(fetch.Messages) == 0 {
+		return channel.Message{}, false, nil
+	}
+	return fetch.Messages[0], true, nil
+}
+
+func loadLatestConversationMessageAuthoritative(ctx context.Context, cluster interface {
+	Status(id channel.ChannelID) (channel.ChannelRuntimeStatus, error)
+	Fetch(ctx context.Context, req channel.FetchRequest) (channel.FetchResult, error)
+}, key channel.ChannelID, maxBytes int, localNodeID, expectedChannelEpoch, expectedLeaderEpoch uint64) (channel.Message, bool, error) {
+	if cluster == nil || localNodeID == 0 {
+		return channel.Message{}, false, channel.ErrStaleMeta
+	}
+	status, err := cluster.Status(key)
+	if err != nil {
+		return channel.Message{}, false, err
+	}
+	if status.Leader == 0 {
+		return channel.Message{}, false, raftcluster.ErrNoLeader
+	}
+	if uint64(status.Leader) != localNodeID {
+		return channel.Message{}, false, channel.ErrNotLeader
+	}
+	if expectedLeaderEpoch != 0 && status.LeaderEpoch != expectedLeaderEpoch {
+		return channel.Message{}, false, channel.ErrStaleMeta
+	}
+
+	fromSeq := status.CommittedSeq
+	if fromSeq == 0 {
+		fromSeq = 1
+	}
+	fetch, err := cluster.Fetch(ctx, channel.FetchRequest{
+		ChannelID:            key,
+		FromSeq:              fromSeq,
+		Limit:                1,
+		MaxBytes:             maxBytes,
+		ExpectedChannelEpoch: expectedChannelEpoch,
+		ExpectedLeaderEpoch:  expectedLeaderEpoch,
+		RequireLeader:        true,
+	})
+	if err != nil {
+		return channel.Message{}, false, err
+	}
+	if status.CommittedSeq == 0 || len(fetch.Messages) == 0 {
 		return channel.Message{}, false, nil
 	}
 	return fetch.Messages[0], true, nil

--- a/internal/app/build.go
+++ b/internal/app/build.go
@@ -1407,7 +1407,7 @@ func (f channelLogConversationFacts) loadLatestMessageAuthoritative(ctx context.
 			if errors.Is(err, metadb.ErrNotFound) {
 				return channel.Message{}, false, channel.ErrChannelNotFound
 			}
-			lastErr = err
+			lastErr = conversationFactsRouteUnavailable(err)
 			if conversationFactsRouteRetryable(lastErr) {
 				if attempt+1 < conversationFactsRouteAttempts {
 					f.metaRefresh.InvalidateChannelMeta(id)
@@ -1442,7 +1442,7 @@ func (f channelLogConversationFacts) loadLatestMessageAuthoritative(ctx context.
 			return msg, ok, nil
 		}
 		if loadErr != nil {
-			lastErr = loadErr
+			lastErr = normalizeConversationFactsAuthoritativeError(loadErr)
 		}
 		if !conversationFactsRouteRetryable(lastErr) {
 			return channel.Message{}, false, lastErr
@@ -1452,6 +1452,24 @@ func (f channelLogConversationFacts) loadLatestMessageAuthoritative(ctx context.
 		}
 	}
 	return channel.Message{}, false, lastErr
+}
+
+func normalizeConversationFactsAuthoritativeError(err error) error {
+	if err == nil ||
+		errors.Is(err, channel.ErrChannelNotFound) ||
+		errors.Is(err, channel.ErrChannelDeleting) ||
+		errors.Is(err, channel.ErrNotReady) ||
+		conversationFactsRouteRetryable(err) {
+		return err
+	}
+	return conversationFactsRouteUnavailable(err)
+}
+
+func conversationFactsRouteUnavailable(err error) error {
+	if errors.Is(err, accessnode.ErrConversationFactsRouteUnavailable) && errors.Is(err, channel.ErrNotReady) {
+		return err
+	}
+	return fmt.Errorf("%w: %w: %v", accessnode.ErrConversationFactsRouteUnavailable, channel.ErrNotReady, err)
 }
 
 func conversationFactsRouteRetryable(err error) bool {

--- a/internal/app/build.go
+++ b/internal/app/build.go
@@ -1366,6 +1366,29 @@ func (f channelLogConversationFacts) LoadLatestMessages(ctx context.Context, key
 	return out, nil
 }
 
+// LoadLatestMessagesAuthoritative resolves every channel to its current leader
+// before loading its latest message. Conversation mutations use this path so a
+// readable but lagging local replica cannot produce a stale read cursor.
+func (f channelLogConversationFacts) LoadLatestMessagesAuthoritative(ctx context.Context, keys []conversationusecase.ConversationKey) (map[conversationusecase.ConversationKey]channel.Message, error) {
+	if len(keys) == 0 {
+		return map[conversationusecase.ConversationKey]channel.Message{}, nil
+	}
+	if remote, ok := f.remote.(batchConversationFactsRemote); ok {
+		return f.loadRemoteLatestMessagesBatch(ctx, remote, keys)
+	}
+	out := make(map[conversationusecase.ConversationKey]channel.Message, len(keys))
+	for _, key := range keys {
+		msg, ok, err := f.loadRemoteLatestMessage(ctx, channel.ChannelID{ID: key.ChannelID, Type: key.ChannelType})
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			out[key] = msg
+		}
+	}
+	return out, nil
+}
+
 func (f channelLogConversationFacts) LoadRecentMessages(ctx context.Context, key conversationusecase.ConversationKey, limit int) ([]channel.Message, error) {
 	if limit <= 0 {
 		return nil, nil

--- a/internal/app/build_test.go
+++ b/internal/app/build_test.go
@@ -185,7 +185,7 @@ func TestChannelLogConversationFactsAuthoritativeFencesStaleLocalLeaderEpoch(t *
 	require.Equal(t, 1, metas.invalidateCalls)
 }
 
-func TestChannelLogConversationFactsAuthoritativeTreatsDeletedLocalChannelAsEmpty(t *testing.T) {
+func TestChannelLogConversationFactsAuthoritativePreservesDeletedLocalChannelError(t *testing.T) {
 	id := channel.ChannelID{ID: "g1", Type: 2}
 	cluster := &readyConversationFactsCluster{
 		status:   channel.ChannelRuntimeStatus{Leader: 1, LeaderEpoch: 12, CommittedSeq: 10},
@@ -202,8 +202,40 @@ func TestChannelLogConversationFactsAuthoritativeTreatsDeletedLocalChannelAsEmpt
 
 	got, err := facts.LoadLatestMessagesAuthoritative(context.Background(), []conversationusecase.ConversationKey{{ChannelID: id.ID, ChannelType: id.Type}})
 
-	require.NoError(t, err)
+	require.ErrorIs(t, err, channel.ErrChannelNotFound)
 	require.Empty(t, got)
+}
+
+func TestChannelLogConversationFactsAuthoritativePreservesRemotePermanentChannelErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "deleting", err: channel.ErrChannelDeleting},
+		{name: "deleted", err: channel.ErrChannelNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := channel.ChannelID{ID: "g1", Type: 2}
+			metas := &staticConversationFactsMetas{metas: map[channel.ChannelID]metadb.ChannelRuntimeMeta{
+				id: {ChannelID: id.ID, ChannelType: int64(id.Type), ChannelEpoch: 11, LeaderEpoch: 12, Leader: 2},
+			}}
+			remote := &recordingConversationFactsRemote{authoritativeErrByNode: map[uint64]error{2: tt.err}}
+			facts := channelLogConversationFacts{
+				cluster:     staleConversationFactsCluster{},
+				remote:      remote,
+				metaRefresh: metas,
+				localNodeID: 1,
+			}
+
+			got, err := facts.LoadLatestMessagesAuthoritative(context.Background(), []conversationusecase.ConversationKey{{ChannelID: id.ID, ChannelType: id.Type}})
+
+			require.ErrorIs(t, err, tt.err)
+			require.Empty(t, got)
+			require.Len(t, remote.authoritativeLatestCalls, 1)
+			require.Zero(t, metas.invalidateCalls)
+		})
+	}
 }
 
 func TestChannelLogConversationFactsAuthoritativeRefreshesAndRetriesStaleLeader(t *testing.T) {

--- a/internal/app/build_test.go
+++ b/internal/app/build_test.go
@@ -265,6 +265,64 @@ func TestChannelLogConversationFactsAuthoritativeReroutesAfterTransportFailure(t
 	require.Equal(t, 1, metas.invalidateCalls)
 }
 
+func TestChannelLogConversationFactsAuthoritativeReroutesAfterMetadataAuthorityFailure(t *testing.T) {
+	id := channel.ChannelID{ID: "g1", Type: 2}
+	metas := &staticConversationFactsMetas{
+		activationErrs: []error{errors.New("dial metadata authority: connection refused")},
+		refreshMetas: []channel.Meta{
+			{ID: id, Epoch: 11, LeaderEpoch: 12, Leader: 3},
+		},
+	}
+	remote := &recordingConversationFactsRemote{
+		latestByNode: map[uint64]map[channel.ChannelID]channel.Message{
+			3: {id: {ChannelID: "g1", ChannelType: 2, MessageSeq: 10}},
+		},
+	}
+	facts := channelLogConversationFacts{
+		cluster:     staleConversationFactsCluster{},
+		remote:      remote,
+		metaRefresh: metas,
+		localNodeID: 1,
+	}
+
+	got, err := facts.LoadLatestMessagesAuthoritative(context.Background(), []conversationusecase.ConversationKey{{ChannelID: id.ID, ChannelType: id.Type}})
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), got[conversationusecase.ConversationKey{ChannelID: id.ID, ChannelType: id.Type}].MessageSeq)
+	require.Len(t, metas.activationSources, 2)
+	require.Equal(t, 1, metas.invalidateCalls)
+}
+
+func TestChannelLogConversationFactsAuthoritativeClassifiesMetadataAuthorityFailuresAsUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "dial failure", err: errors.New("dial tcp: connection refused")},
+		{name: "deadline", err: context.DeadlineExceeded},
+		{name: "canceled", err: context.Canceled},
+		{name: "not ready", err: channel.ErrNotReady},
+		{name: "slot unavailable", err: errors.New("cluster: slot 42 has no leader available")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metas := &staticConversationFactsMetas{activationErrs: []error{tt.err, tt.err}}
+			facts := channelLogConversationFacts{
+				cluster:     staleConversationFactsCluster{},
+				metaRefresh: metas,
+				localNodeID: 1,
+			}
+
+			_, err := facts.LoadLatestMessagesAuthoritative(context.Background(), []conversationusecase.ConversationKey{{ChannelID: "g1", ChannelType: 2}})
+
+			require.ErrorIs(t, err, channel.ErrNotReady)
+			require.ErrorIs(t, err, accessnode.ErrConversationFactsRouteUnavailable)
+			require.Len(t, metas.activationSources, 2)
+			require.Equal(t, 1, metas.invalidateCalls)
+		})
+	}
+}
+
 func TestChannelLogConversationFactsSupportsBatchRecentLoadsByOwner(t *testing.T) {
 	remote := &recordingConversationFactsRemote{
 		recentsByNode: map[uint64]map[channel.ChannelID][]channel.Message{
@@ -558,13 +616,18 @@ type staticConversationFactsMetas struct {
 	batchCalls        int
 	refreshCalls      int
 	activationSources []channelruntime.ActivationSource
+	activationErrs    []error
 	invalidateCalls   int
 	invalidated       bool
 	refreshMetas      []channel.Meta
 }
 
 func (s *staticConversationFactsMetas) ActivateByID(ctx context.Context, id channel.ChannelID, source channelruntime.ActivationSource) (channel.Meta, error) {
+	callIndex := len(s.activationSources)
 	s.activationSources = append(s.activationSources, source)
+	if callIndex < len(s.activationErrs) && s.activationErrs[callIndex] != nil {
+		return channel.Meta{}, s.activationErrs[callIndex]
+	}
 	return s.RefreshChannelMeta(ctx, id)
 }
 

--- a/internal/app/build_test.go
+++ b/internal/app/build_test.go
@@ -11,8 +11,10 @@ import (
 	"time"
 	"unsafe"
 
+	accessnode "github.com/WuKongIM/WuKongIM/internal/access/node"
 	conversationusecase "github.com/WuKongIM/WuKongIM/internal/usecase/conversation"
 	"github.com/WuKongIM/WuKongIM/pkg/channel"
+	channelruntime "github.com/WuKongIM/WuKongIM/pkg/channel/runtime"
 	raftcluster "github.com/WuKongIM/WuKongIM/pkg/cluster"
 	channelstore "github.com/WuKongIM/WuKongIM/pkg/db/message"
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
@@ -109,6 +111,26 @@ func TestChannelLogConversationFactsLoadLatestMessagesAuthoritativeUsesOwner(t *
 		ExpectedLeaderEpoch:  12,
 	}}, remote.authoritativeLatestCalls)
 	require.Equal(t, 1, metas.refreshCalls)
+	require.Equal(t, []channelruntime.ActivationSource{channelruntime.ActivationSourceFetch}, metas.activationSources)
+}
+
+func TestChannelLogConversationFactsAuthoritativeDoesNotBootstrapUnknownChannel(t *testing.T) {
+	id := channel.ChannelID{ID: "missing", Type: 2}
+	metas := &staticConversationFactsMetas{metas: map[channel.ChannelID]metadb.ChannelRuntimeMeta{}}
+	remote := &recordingConversationFactsRemote{}
+	facts := channelLogConversationFacts{
+		cluster:     staleConversationFactsCluster{},
+		remote:      remote,
+		metaRefresh: metas,
+		localNodeID: 1,
+	}
+
+	_, err := facts.LoadLatestMessagesAuthoritative(context.Background(), []conversationusecase.ConversationKey{{ChannelID: id.ID, ChannelType: id.Type}})
+
+	require.ErrorIs(t, err, channel.ErrChannelNotFound)
+	require.Equal(t, []channelruntime.ActivationSource{channelruntime.ActivationSourceFetch}, metas.activationSources)
+	require.Zero(t, metas.invalidateCalls)
+	require.Empty(t, remote.authoritativeLatestCalls)
 }
 
 func TestChannelLogConversationFactsAuthoritativeUsesLocalLeaderWithoutRPC(t *testing.T) {
@@ -163,6 +185,27 @@ func TestChannelLogConversationFactsAuthoritativeFencesStaleLocalLeaderEpoch(t *
 	require.Equal(t, 1, metas.invalidateCalls)
 }
 
+func TestChannelLogConversationFactsAuthoritativeTreatsDeletedLocalChannelAsEmpty(t *testing.T) {
+	id := channel.ChannelID{ID: "g1", Type: 2}
+	cluster := &readyConversationFactsCluster{
+		status:   channel.ChannelRuntimeStatus{Leader: 1, LeaderEpoch: 12, CommittedSeq: 10},
+		fetchErr: channel.ErrChannelNotFound,
+	}
+	metas := &staticConversationFactsMetas{metas: map[channel.ChannelID]metadb.ChannelRuntimeMeta{
+		id: {ChannelID: id.ID, ChannelType: int64(id.Type), ChannelEpoch: 11, LeaderEpoch: 12, Leader: 1},
+	}}
+	facts := channelLogConversationFacts{
+		cluster:     cluster,
+		metaRefresh: metas,
+		localNodeID: 1,
+	}
+
+	got, err := facts.LoadLatestMessagesAuthoritative(context.Background(), []conversationusecase.ConversationKey{{ChannelID: id.ID, ChannelType: id.Type}})
+
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
 func TestChannelLogConversationFactsAuthoritativeRefreshesAndRetriesStaleLeader(t *testing.T) {
 	id := channel.ChannelID{ID: "g1", Type: 2}
 	metas := &staticConversationFactsMetas{refreshMetas: []channel.Meta{
@@ -190,6 +233,35 @@ func TestChannelLogConversationFactsAuthoritativeRefreshesAndRetriesStaleLeader(
 		{NodeID: 3, Key: id, ExpectedChannelEpoch: 11, ExpectedLeaderEpoch: 13},
 	}, remote.authoritativeLatestCalls)
 	require.Equal(t, 2, metas.refreshCalls)
+	require.Equal(t, 1, metas.invalidateCalls)
+}
+
+func TestChannelLogConversationFactsAuthoritativeReroutesAfterTransportFailure(t *testing.T) {
+	id := channel.ChannelID{ID: "g1", Type: 2}
+	metas := &staticConversationFactsMetas{refreshMetas: []channel.Meta{
+		{ID: id, Epoch: 11, LeaderEpoch: 12, Leader: 2},
+		{ID: id, Epoch: 11, LeaderEpoch: 13, Leader: 3},
+	}}
+	remote := &recordingConversationFactsRemote{
+		latestByNode: map[uint64]map[channel.ChannelID]channel.Message{
+			3: {id: {ChannelID: "g1", ChannelType: 2, MessageSeq: 10}},
+		},
+		authoritativeErrByNode: map[uint64]error{2: accessnode.ErrConversationFactsRouteUnavailable},
+	}
+	facts := channelLogConversationFacts{
+		cluster:     staleConversationFactsCluster{},
+		remote:      remote,
+		metaRefresh: metas,
+		localNodeID: 1,
+	}
+
+	got, err := facts.LoadLatestMessagesAuthoritative(context.Background(), []conversationusecase.ConversationKey{{ChannelID: "g1", ChannelType: 2}})
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), got[conversationusecase.ConversationKey{ChannelID: "g1", ChannelType: 2}].MessageSeq)
+	require.Equal(t, []authoritativeConversationFactsCall{
+		{NodeID: 2, Key: id, ExpectedChannelEpoch: 11, ExpectedLeaderEpoch: 12},
+		{NodeID: 3, Key: id, ExpectedChannelEpoch: 11, ExpectedLeaderEpoch: 13},
+	}, remote.authoritativeLatestCalls)
 	require.Equal(t, 1, metas.invalidateCalls)
 }
 
@@ -465,9 +537,10 @@ func (notReadyConversationFactsCluster) Fetch(context.Context, channel.FetchRequ
 }
 
 type readyConversationFactsCluster struct {
-	status  channel.ChannelRuntimeStatus
-	fetch   channel.FetchResult
-	fetches []channel.FetchRequest
+	status   channel.ChannelRuntimeStatus
+	fetch    channel.FetchResult
+	fetchErr error
+	fetches  []channel.FetchRequest
 }
 
 func (c *readyConversationFactsCluster) Status(channel.ChannelID) (channel.ChannelRuntimeStatus, error) {
@@ -476,17 +549,23 @@ func (c *readyConversationFactsCluster) Status(channel.ChannelID) (channel.Chann
 
 func (c *readyConversationFactsCluster) Fetch(_ context.Context, req channel.FetchRequest) (channel.FetchResult, error) {
 	c.fetches = append(c.fetches, req)
-	return c.fetch, nil
+	return c.fetch, c.fetchErr
 }
 
 type staticConversationFactsMetas struct {
-	metas           map[channel.ChannelID]metadb.ChannelRuntimeMeta
-	singularErr     error
-	batchCalls      int
-	refreshCalls    int
-	invalidateCalls int
-	invalidated     bool
-	refreshMetas    []channel.Meta
+	metas             map[channel.ChannelID]metadb.ChannelRuntimeMeta
+	singularErr       error
+	batchCalls        int
+	refreshCalls      int
+	activationSources []channelruntime.ActivationSource
+	invalidateCalls   int
+	invalidated       bool
+	refreshMetas      []channel.Meta
+}
+
+func (s *staticConversationFactsMetas) ActivateByID(ctx context.Context, id channel.ChannelID, source channelruntime.ActivationSource) (channel.Meta, error) {
+	s.activationSources = append(s.activationSources, source)
+	return s.RefreshChannelMeta(ctx, id)
 }
 
 func (s *staticConversationFactsMetas) RefreshChannelMeta(_ context.Context, id channel.ChannelID) (channel.Meta, error) {

--- a/internal/app/build_test.go
+++ b/internal/app/build_test.go
@@ -138,6 +138,31 @@ func TestChannelLogConversationFactsAuthoritativeUsesLocalLeaderWithoutRPC(t *te
 	require.Equal(t, uint64(12), cluster.fetches[0].ExpectedLeaderEpoch)
 }
 
+func TestChannelLogConversationFactsAuthoritativeFencesStaleLocalLeaderEpoch(t *testing.T) {
+	id := channel.ChannelID{ID: "g1", Type: 2}
+	cluster := &readyConversationFactsCluster{
+		status: channel.ChannelRuntimeStatus{Leader: 1, LeaderEpoch: 13, CommittedSeq: 10},
+	}
+	metas := &staticConversationFactsMetas{metas: map[channel.ChannelID]metadb.ChannelRuntimeMeta{
+		id: {ChannelID: id.ID, ChannelType: int64(id.Type), ChannelEpoch: 11, LeaderEpoch: 12, Leader: 1},
+	}}
+	remote := &recordingConversationFactsRemote{}
+	facts := channelLogConversationFacts{
+		cluster:     cluster,
+		remote:      remote,
+		metaRefresh: metas,
+		localNodeID: 1,
+	}
+
+	_, err := facts.LoadLatestMessagesAuthoritative(context.Background(), []conversationusecase.ConversationKey{{ChannelID: id.ID, ChannelType: id.Type}})
+
+	require.ErrorIs(t, err, channel.ErrStaleMeta)
+	require.Empty(t, cluster.fetches)
+	require.Empty(t, remote.authoritativeLatestCalls)
+	require.Equal(t, 2, metas.refreshCalls)
+	require.Equal(t, 1, metas.invalidateCalls)
+}
+
 func TestChannelLogConversationFactsAuthoritativeRefreshesAndRetriesStaleLeader(t *testing.T) {
 	id := channel.ChannelID{ID: "g1", Type: 2}
 	metas := &staticConversationFactsMetas{refreshMetas: []channel.Meta{
@@ -165,6 +190,7 @@ func TestChannelLogConversationFactsAuthoritativeRefreshesAndRetriesStaleLeader(
 		{NodeID: 3, Key: id, ExpectedChannelEpoch: 11, ExpectedLeaderEpoch: 13},
 	}, remote.authoritativeLatestCalls)
 	require.Equal(t, 2, metas.refreshCalls)
+	require.Equal(t, 1, metas.invalidateCalls)
 }
 
 func TestChannelLogConversationFactsSupportsBatchRecentLoadsByOwner(t *testing.T) {
@@ -454,19 +480,21 @@ func (c *readyConversationFactsCluster) Fetch(_ context.Context, req channel.Fet
 }
 
 type staticConversationFactsMetas struct {
-	metas        map[channel.ChannelID]metadb.ChannelRuntimeMeta
-	singularErr  error
-	batchCalls   int
-	refreshCalls int
-	refreshMetas []channel.Meta
+	metas           map[channel.ChannelID]metadb.ChannelRuntimeMeta
+	singularErr     error
+	batchCalls      int
+	refreshCalls    int
+	invalidateCalls int
+	invalidated     bool
+	refreshMetas    []channel.Meta
 }
 
 func (s *staticConversationFactsMetas) RefreshChannelMeta(_ context.Context, id channel.ChannelID) (channel.Meta, error) {
 	s.refreshCalls++
 	if len(s.refreshMetas) > 0 {
-		index := s.refreshCalls - 1
-		if index >= len(s.refreshMetas) {
-			index = len(s.refreshMetas) - 1
+		index := 0
+		if s.invalidated && len(s.refreshMetas) > 1 {
+			index = 1
 		}
 		return s.refreshMetas[index], nil
 	}
@@ -480,6 +508,11 @@ func (s *staticConversationFactsMetas) RefreshChannelMeta(_ context.Context, id 
 		LeaderEpoch: meta.LeaderEpoch,
 		Leader:      channel.NodeID(meta.Leader),
 	}, nil
+}
+
+func (s *staticConversationFactsMetas) InvalidateChannelMeta(channel.ChannelID) {
+	s.invalidateCalls++
+	s.invalidated = true
 }
 
 func (s *staticConversationFactsMetas) GetChannelRuntimeMeta(_ context.Context, channelID string, channelType int64) (metadb.ChannelRuntimeMeta, error) {

--- a/internal/app/build_test.go
+++ b/internal/app/build_test.go
@@ -74,6 +74,38 @@ func TestChannelLogConversationFactsLoadLatestMessagesBatchesRemoteLoadsByOwner(
 	require.Equal(t, 1, metas.batchCalls)
 }
 
+func TestChannelLogConversationFactsLoadLatestMessagesAuthoritativeUsesOwner(t *testing.T) {
+	remote := &recordingConversationFactsRemote{
+		latestByNode: map[uint64]map[channel.ChannelID]channel.Message{
+			3: {
+				{ID: "g1", Type: 2}: {ChannelID: "g1", ChannelType: 2, MessageSeq: 10},
+			},
+		},
+	}
+	metas := &staticConversationFactsMetas{
+		metas: map[channel.ChannelID]metadb.ChannelRuntimeMeta{
+			{ID: "g1", Type: 2}: {ChannelID: "g1", ChannelType: 2, Leader: 3},
+		},
+	}
+	facts := channelLogConversationFacts{
+		cluster: notReadyConversationFactsCluster{},
+		metas:   metas,
+		remote:  remote,
+	}
+
+	got, err := facts.LoadLatestMessagesAuthoritative(context.Background(), []conversationusecase.ConversationKey{
+		{ChannelID: "g1", ChannelType: 2},
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[conversationusecase.ConversationKey]channel.Message{
+		{ChannelID: "g1", ChannelType: 2}: {ChannelID: "g1", ChannelType: 2, MessageSeq: 10},
+	}, got)
+	require.Equal(t, []conversationFactsBatchCall{
+		{NodeID: 3, Keys: []channel.ChannelID{{ID: "g1", Type: 2}}},
+	}, remote.latestBatchCalls)
+	require.Equal(t, 1, metas.batchCalls)
+}
+
 func TestChannelLogConversationFactsSupportsBatchRecentLoadsByOwner(t *testing.T) {
 	remote := &recordingConversationFactsRemote{
 		recentsByNode: map[uint64]map[channel.ChannelID][]channel.Message{

--- a/internal/app/build_test.go
+++ b/internal/app/build_test.go
@@ -84,13 +84,15 @@ func TestChannelLogConversationFactsLoadLatestMessagesAuthoritativeUsesOwner(t *
 	}
 	metas := &staticConversationFactsMetas{
 		metas: map[channel.ChannelID]metadb.ChannelRuntimeMeta{
-			{ID: "g1", Type: 2}: {ChannelID: "g1", ChannelType: 2, Leader: 3},
+			{ID: "g1", Type: 2}: {ChannelID: "g1", ChannelType: 2, ChannelEpoch: 11, LeaderEpoch: 12, Leader: 3},
 		},
 	}
 	facts := channelLogConversationFacts{
-		cluster: notReadyConversationFactsCluster{},
-		metas:   metas,
-		remote:  remote,
+		cluster:     notReadyConversationFactsCluster{},
+		metas:       metas,
+		remote:      remote,
+		metaRefresh: metas,
+		localNodeID: 1,
 	}
 
 	got, err := facts.LoadLatestMessagesAuthoritative(context.Background(), []conversationusecase.ConversationKey{
@@ -100,10 +102,69 @@ func TestChannelLogConversationFactsLoadLatestMessagesAuthoritativeUsesOwner(t *
 	require.Equal(t, map[conversationusecase.ConversationKey]channel.Message{
 		{ChannelID: "g1", ChannelType: 2}: {ChannelID: "g1", ChannelType: 2, MessageSeq: 10},
 	}, got)
-	require.Equal(t, []conversationFactsBatchCall{
-		{NodeID: 3, Keys: []channel.ChannelID{{ID: "g1", Type: 2}}},
-	}, remote.latestBatchCalls)
-	require.Equal(t, 1, metas.batchCalls)
+	require.Equal(t, []authoritativeConversationFactsCall{{
+		NodeID:               3,
+		Key:                  channel.ChannelID{ID: "g1", Type: 2},
+		ExpectedChannelEpoch: 11,
+		ExpectedLeaderEpoch:  12,
+	}}, remote.authoritativeLatestCalls)
+	require.Equal(t, 1, metas.refreshCalls)
+}
+
+func TestChannelLogConversationFactsAuthoritativeUsesLocalLeaderWithoutRPC(t *testing.T) {
+	cluster := &readyConversationFactsCluster{
+		status: channel.ChannelRuntimeStatus{Leader: 1, LeaderEpoch: 12, CommittedSeq: 10},
+		fetch:  channel.FetchResult{Messages: []channel.Message{{ChannelID: "g1", ChannelType: 2, MessageSeq: 10}}},
+	}
+	metas := &staticConversationFactsMetas{metas: map[channel.ChannelID]metadb.ChannelRuntimeMeta{
+		{ID: "g1", Type: 2}: {ChannelID: "g1", ChannelType: 2, ChannelEpoch: 11, LeaderEpoch: 12, Leader: 1},
+	}}
+	remote := &recordingConversationFactsRemote{}
+	facts := channelLogConversationFacts{
+		cluster:     cluster,
+		metas:       metas,
+		remote:      remote,
+		metaRefresh: metas,
+		localNodeID: 1,
+	}
+
+	got, err := facts.LoadLatestMessagesAuthoritative(context.Background(), []conversationusecase.ConversationKey{{ChannelID: "g1", ChannelType: 2}})
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), got[conversationusecase.ConversationKey{ChannelID: "g1", ChannelType: 2}].MessageSeq)
+	require.Empty(t, remote.authoritativeLatestCalls)
+	require.Len(t, cluster.fetches, 1)
+	require.True(t, cluster.fetches[0].RequireLeader)
+	require.Equal(t, uint64(11), cluster.fetches[0].ExpectedChannelEpoch)
+	require.Equal(t, uint64(12), cluster.fetches[0].ExpectedLeaderEpoch)
+}
+
+func TestChannelLogConversationFactsAuthoritativeRefreshesAndRetriesStaleLeader(t *testing.T) {
+	id := channel.ChannelID{ID: "g1", Type: 2}
+	metas := &staticConversationFactsMetas{refreshMetas: []channel.Meta{
+		{ID: id, Epoch: 11, LeaderEpoch: 12, Leader: 2},
+		{ID: id, Epoch: 11, LeaderEpoch: 13, Leader: 3},
+	}}
+	remote := &recordingConversationFactsRemote{
+		latestByNode: map[uint64]map[channel.ChannelID]channel.Message{
+			3: {id: {ChannelID: "g1", ChannelType: 2, MessageSeq: 10}},
+		},
+		authoritativeErrByNode: map[uint64]error{2: channel.ErrNotLeader},
+	}
+	facts := channelLogConversationFacts{
+		cluster:     staleConversationFactsCluster{},
+		remote:      remote,
+		metaRefresh: metas,
+		localNodeID: 1,
+	}
+
+	got, err := facts.LoadLatestMessagesAuthoritative(context.Background(), []conversationusecase.ConversationKey{{ChannelID: "g1", ChannelType: 2}})
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), got[conversationusecase.ConversationKey{ChannelID: "g1", ChannelType: 2}].MessageSeq)
+	require.Equal(t, []authoritativeConversationFactsCall{
+		{NodeID: 2, Key: id, ExpectedChannelEpoch: 11, ExpectedLeaderEpoch: 12},
+		{NodeID: 3, Key: id, ExpectedChannelEpoch: 11, ExpectedLeaderEpoch: 13},
+	}, remote.authoritativeLatestCalls)
+	require.Equal(t, 2, metas.refreshCalls)
 }
 
 func TestChannelLogConversationFactsSupportsBatchRecentLoadsByOwner(t *testing.T) {
@@ -377,10 +438,48 @@ func (notReadyConversationFactsCluster) Fetch(context.Context, channel.FetchRequ
 	return channel.FetchResult{}, channel.ErrNotReady
 }
 
+type readyConversationFactsCluster struct {
+	status  channel.ChannelRuntimeStatus
+	fetch   channel.FetchResult
+	fetches []channel.FetchRequest
+}
+
+func (c *readyConversationFactsCluster) Status(channel.ChannelID) (channel.ChannelRuntimeStatus, error) {
+	return c.status, nil
+}
+
+func (c *readyConversationFactsCluster) Fetch(_ context.Context, req channel.FetchRequest) (channel.FetchResult, error) {
+	c.fetches = append(c.fetches, req)
+	return c.fetch, nil
+}
+
 type staticConversationFactsMetas struct {
-	metas       map[channel.ChannelID]metadb.ChannelRuntimeMeta
-	singularErr error
-	batchCalls  int
+	metas        map[channel.ChannelID]metadb.ChannelRuntimeMeta
+	singularErr  error
+	batchCalls   int
+	refreshCalls int
+	refreshMetas []channel.Meta
+}
+
+func (s *staticConversationFactsMetas) RefreshChannelMeta(_ context.Context, id channel.ChannelID) (channel.Meta, error) {
+	s.refreshCalls++
+	if len(s.refreshMetas) > 0 {
+		index := s.refreshCalls - 1
+		if index >= len(s.refreshMetas) {
+			index = len(s.refreshMetas) - 1
+		}
+		return s.refreshMetas[index], nil
+	}
+	meta, ok := s.metas[id]
+	if !ok {
+		return channel.Meta{}, metadb.ErrNotFound
+	}
+	return channel.Meta{
+		ID:          id,
+		Epoch:       meta.ChannelEpoch,
+		LeaderEpoch: meta.LeaderEpoch,
+		Leader:      channel.NodeID(meta.Leader),
+	}, nil
 }
 
 func (s *staticConversationFactsMetas) GetChannelRuntimeMeta(_ context.Context, channelID string, channelType int64) (metadb.ChannelRuntimeMeta, error) {
@@ -411,15 +510,41 @@ type conversationFactsBatchCall struct {
 	Keys   []channel.ChannelID
 }
 
+type authoritativeConversationFactsCall struct {
+	NodeID               uint64
+	Key                  channel.ChannelID
+	ExpectedChannelEpoch uint64
+	ExpectedLeaderEpoch  uint64
+}
+
 type recordingConversationFactsRemote struct {
-	latestByNode        map[uint64]map[channel.ChannelID]channel.Message
-	recentsByNode       map[uint64]map[channel.ChannelID][]channel.Message
-	latestBatchCalls    []conversationFactsBatchCall
-	recentBatchCalls    []conversationFactsBatchCall
-	singularLatestCalls []channel.ChannelID
-	singularRecentCalls []channel.ChannelID
-	singularLatestErr   error
-	singularRecentErr   error
+	latestByNode             map[uint64]map[channel.ChannelID]channel.Message
+	recentsByNode            map[uint64]map[channel.ChannelID][]channel.Message
+	latestBatchCalls         []conversationFactsBatchCall
+	recentBatchCalls         []conversationFactsBatchCall
+	authoritativeLatestCalls []authoritativeConversationFactsCall
+	authoritativeErrByNode   map[uint64]error
+	singularLatestCalls      []channel.ChannelID
+	singularRecentCalls      []channel.ChannelID
+	singularLatestErr        error
+	singularRecentErr        error
+}
+
+func (r *recordingConversationFactsRemote) LoadLatestConversationMessageAuthoritative(_ context.Context, nodeID uint64, key channel.ChannelID, _ int, expectedChannelEpoch, expectedLeaderEpoch uint64) (channel.Message, bool, error) {
+	r.authoritativeLatestCalls = append(r.authoritativeLatestCalls, authoritativeConversationFactsCall{
+		NodeID:               nodeID,
+		Key:                  key,
+		ExpectedChannelEpoch: expectedChannelEpoch,
+		ExpectedLeaderEpoch:  expectedLeaderEpoch,
+	})
+	if err := r.authoritativeErrByNode[nodeID]; err != nil {
+		return channel.Message{}, false, err
+	}
+	if r.singularLatestErr != nil {
+		return channel.Message{}, false, r.singularLatestErr
+	}
+	msg, ok := r.latestByNode[nodeID][key]
+	return msg, ok, nil
 }
 
 func (r *recordingConversationFactsRemote) LoadLatestConversationMessage(_ context.Context, _ uint64, key channel.ChannelID, _ int) (channel.Message, bool, error) {

--- a/internal/usecase/conversation/app.go
+++ b/internal/usecase/conversation/app.go
@@ -17,6 +17,7 @@ type Options struct {
 	States                ConversationStateStore
 	Deletes               ConversationDeleteStore
 	Facts                 MessageFactsStore
+	AuthoritativeFacts    AuthoritativeMessageFactsStore
 	Now                   func() time.Time
 	ActiveScanLimit       int
 	ChannelProbeBatchSize int
@@ -26,12 +27,13 @@ type Options struct {
 }
 
 type App struct {
-	states          ConversationStateStore
-	deletes         ConversationDeleteStore
-	facts           MessageFactsStore
-	now             func() time.Time
-	async           func(func())
-	activeScanLimit int
+	states             ConversationStateStore
+	deletes            ConversationDeleteStore
+	facts              MessageFactsStore
+	authoritativeFacts AuthoritativeMessageFactsStore
+	now                func() time.Time
+	async              func(func())
+	activeScanLimit    int
 }
 
 func New(opts Options) *App {
@@ -51,11 +53,12 @@ func New(opts Options) *App {
 	}
 
 	return &App{
-		states:          opts.States,
-		deletes:         opts.Deletes,
-		facts:           opts.Facts,
-		now:             opts.Now,
-		async:           opts.Async,
-		activeScanLimit: opts.ActiveScanLimit,
+		states:             opts.States,
+		deletes:            opts.Deletes,
+		facts:              opts.Facts,
+		authoritativeFacts: opts.AuthoritativeFacts,
+		now:                opts.Now,
+		async:              opts.Async,
+		activeScanLimit:    opts.ActiveScanLimit,
 	}
 }

--- a/internal/usecase/conversation/delete.go
+++ b/internal/usecase/conversation/delete.go
@@ -29,7 +29,7 @@ func (a *App) DeleteConversation(ctx context.Context, cmd DeleteConversationComm
 			return err
 		}
 		if !ok || latestSeq == 0 {
-			return errors.New("conversation latest message not found")
+			return ErrLatestMessageUnavailable
 		}
 		deleteSeq = latestSeq
 	}

--- a/internal/usecase/conversation/delete_test.go
+++ b/internal/usecase/conversation/delete_test.go
@@ -14,11 +14,12 @@ func TestDeleteConversationHidesStateClearsActiveAtAndRemovesHotHint(t *testing.
 	now := time.Unix(123, 0)
 	repo := newConversationDeleteRepoStub()
 	app := New(Options{
-		States:  repo,
-		Deletes: repo,
-		Facts:   repo,
-		Now:     func() time.Time { return now },
-		Async:   func(fn func()) { fn() },
+		States:             repo,
+		Deletes:            repo,
+		Facts:              repo,
+		AuthoritativeFacts: repo,
+		Now:                func() time.Time { return now },
+		Async:              func(fn func()) { fn() },
 	})
 
 	err := app.DeleteConversation(context.Background(), DeleteConversationCommand{
@@ -48,13 +49,21 @@ func TestDeleteConversationHidesStateClearsActiveAtAndRemovesHotHint(t *testing.
 func TestDeleteConversationUsesLatestMessageSeqWhenCommandSeqIsZero(t *testing.T) {
 	now := time.Unix(123, 0)
 	repo := newConversationDeleteRepoStub()
-	repo.latest[key("g1", 2)] = channel.Message{ChannelID: "g1", ChannelType: 2, MessageSeq: 15}
+	repo.latest[key("g1", 2)] = channel.Message{ChannelID: "g1", ChannelType: 2, MessageSeq: 8}
+	baseFacts := newConversationSyncRepoStub()
+	authoritativeFacts := &authoritativeConversationFactsStub{
+		conversationSyncRepoStub: baseFacts,
+		latest: map[ConversationKey]channel.Message{
+			key("g1", 2): {ChannelID: "g1", ChannelType: 2, MessageSeq: 15},
+		},
+	}
 	app := New(Options{
-		States:  repo,
-		Deletes: repo,
-		Facts:   repo,
-		Now:     func() time.Time { return now },
-		Async:   func(fn func()) { fn() },
+		States:             repo,
+		Deletes:            repo,
+		Facts:              repo,
+		AuthoritativeFacts: authoritativeFacts,
+		Now:                func() time.Time { return now },
+		Async:              func(fn func()) { fn() },
 	})
 
 	err := app.DeleteConversation(context.Background(), DeleteConversationCommand{
@@ -65,15 +74,17 @@ func TestDeleteConversationUsesLatestMessageSeqWhenCommandSeqIsZero(t *testing.T
 
 	require.NoError(t, err)
 	require.Equal(t, uint64(15), repo.hides[0].DeletedToSeq)
-	require.Equal(t, []ConversationKey{key("g1", 2)}, repo.latestLoads)
+	require.Equal(t, []ConversationKey{key("g1", 2)}, authoritativeFacts.loads)
+	require.Empty(t, repo.latestLoads)
 }
 
 func TestDeleteConversationReturnsErrorWhenLatestMessageSeqMissing(t *testing.T) {
 	repo := newConversationDeleteRepoStub()
 	app := New(Options{
-		States:  repo,
-		Deletes: repo,
-		Facts:   repo,
+		States:             repo,
+		Deletes:            repo,
+		Facts:              repo,
+		AuthoritativeFacts: repo,
 	})
 
 	err := app.DeleteConversation(context.Background(), DeleteConversationCommand{
@@ -103,9 +114,10 @@ func TestDeleteConversationDoesNotWaitForHotHintRemoval(t *testing.T) {
 		}
 	}
 	app := New(Options{
-		States:  repo,
-		Deletes: repo,
-		Facts:   repo,
+		States:             repo,
+		Deletes:            repo,
+		Facts:              repo,
+		AuthoritativeFacts: repo,
 	})
 
 	done := make(chan error, 1)
@@ -153,11 +165,12 @@ func TestDeleteConversationAllowsNewerMessageReactivation(t *testing.T) {
 	})
 	repo.cache = cache
 	app := New(Options{
-		States:  repo,
-		Deletes: repo,
-		Facts:   repo,
-		Now:     func() time.Time { return now },
-		Async:   func(fn func()) { fn() },
+		States:             repo,
+		Deletes:            repo,
+		Facts:              repo,
+		AuthoritativeFacts: repo,
+		Now:                func() time.Time { return now },
+		Async:              func(fn func()) { fn() },
 	})
 	require.NoError(t, cache.SubmitHints(context.Background(), []metadb.UserConversationActiveHint{
 		{UID: "u1", ChannelID: "g1", ChannelType: 2, ActiveAt: 100, MessageSeq: 10},
@@ -233,6 +246,10 @@ func (r *conversationDeleteRepoStub) LoadLatestMessages(_ context.Context, keys 
 		}
 	}
 	return out, nil
+}
+
+func (r *conversationDeleteRepoStub) LoadLatestMessagesAuthoritative(ctx context.Context, keys []ConversationKey) (map[ConversationKey]channel.Message, error) {
+	return r.LoadLatestMessages(ctx, keys)
 }
 
 func (r *conversationDeleteRepoStub) LoadRecentMessages(context.Context, ConversationKey, int) ([]channel.Message, error) {

--- a/internal/usecase/conversation/delete_test.go
+++ b/internal/usecase/conversation/delete_test.go
@@ -93,7 +93,7 @@ func TestDeleteConversationReturnsErrorWhenLatestMessageSeqMissing(t *testing.T)
 		ChannelType: 2,
 	})
 
-	require.ErrorContains(t, err, "latest message not found")
+	require.ErrorIs(t, err, ErrLatestMessageUnavailable)
 	require.Empty(t, repo.hides)
 	require.Empty(t, repo.removedBarriers)
 }

--- a/internal/usecase/conversation/deps.go
+++ b/internal/usecase/conversation/deps.go
@@ -23,6 +23,13 @@ type MessageFactsStore interface {
 	LoadRecentMessages(ctx context.Context, key ConversationKey, limit int) ([]channel.Message, error)
 }
 
+// authoritativeMessageFactsStore is implemented by stores that can route a
+// latest-message read to the channel leader. Mutations prefer this path so a
+// readable but lagging local replica cannot produce a stale read cursor.
+type authoritativeMessageFactsStore interface {
+	LoadLatestMessagesAuthoritative(ctx context.Context, keys []ConversationKey) (map[ConversationKey]channel.Message, error)
+}
+
 type ProjectorStore interface {
 	SubmitUserConversationActiveHints(ctx context.Context, hints []metadb.UserConversationActiveHint) error
 	ListChannelSubscribers(ctx context.Context, channelID string, channelType int64, afterUID string, limit int) ([]string, string, bool, error)

--- a/internal/usecase/conversation/deps.go
+++ b/internal/usecase/conversation/deps.go
@@ -23,10 +23,9 @@ type MessageFactsStore interface {
 	LoadRecentMessages(ctx context.Context, key ConversationKey, limit int) ([]channel.Message, error)
 }
 
-// authoritativeMessageFactsStore is implemented by stores that can route a
-// latest-message read to the channel leader. Mutations prefer this path so a
-// readable but lagging local replica cannot produce a stale read cursor.
-type authoritativeMessageFactsStore interface {
+// AuthoritativeMessageFactsStore routes latest-message reads to the current
+// channel leader and fails closed when leadership cannot be proven.
+type AuthoritativeMessageFactsStore interface {
 	LoadLatestMessagesAuthoritative(ctx context.Context, keys []ConversationKey) (map[ConversationKey]channel.Message, error)
 }
 

--- a/internal/usecase/conversation/errors.go
+++ b/internal/usecase/conversation/errors.go
@@ -1,0 +1,7 @@
+package conversation
+
+import "errors"
+
+// ErrLatestMessageUnavailable means a delete boundary cannot be derived from
+// the channel log because no latest message payload is available.
+var ErrLatestMessageUnavailable = errors.New("conversation latest message unavailable")

--- a/internal/usecase/conversation/sync_test.go
+++ b/internal/usecase/conversation/sync_test.go
@@ -244,6 +244,10 @@ func (r *conversationSyncRepoStub) LoadLatestMessages(_ context.Context, keys []
 	return out, nil
 }
 
+func (r *conversationSyncRepoStub) LoadLatestMessagesAuthoritative(ctx context.Context, keys []ConversationKey) (map[ConversationKey]channel.Message, error) {
+	return r.LoadLatestMessages(ctx, keys)
+}
+
 func (r *conversationSyncRepoStub) LoadRecentMessages(_ context.Context, key ConversationKey, limit int) ([]channel.Message, error) {
 	if r.recentLoadErr != nil {
 		return nil, r.recentLoadErr

--- a/internal/usecase/conversation/unread.go
+++ b/internal/usecase/conversation/unread.go
@@ -60,14 +60,10 @@ func validateUnreadTarget(uid, channelID string, channelType uint8) error {
 }
 
 func (a *App) latestConversationSeq(ctx context.Context, key ConversationKey, fallback uint64) (uint64, bool, error) {
-	if a.facts == nil {
-		return 0, false, errors.New("message facts store not configured")
+	if a.authoritativeFacts == nil {
+		return 0, false, errors.New("authoritative message facts store not configured")
 	}
-	loadLatest := a.facts.LoadLatestMessages
-	if authoritative, ok := a.facts.(authoritativeMessageFactsStore); ok {
-		loadLatest = authoritative.LoadLatestMessagesAuthoritative
-	}
-	latestByKey, err := loadLatest(ctx, []ConversationKey{key})
+	latestByKey, err := a.authoritativeFacts.LoadLatestMessagesAuthoritative(ctx, []ConversationKey{key})
 	if err != nil {
 		return 0, false, err
 	}

--- a/internal/usecase/conversation/unread.go
+++ b/internal/usecase/conversation/unread.go
@@ -63,7 +63,11 @@ func (a *App) latestConversationSeq(ctx context.Context, key ConversationKey, fa
 	if a.facts == nil {
 		return 0, false, errors.New("message facts store not configured")
 	}
-	latestByKey, err := a.facts.LoadLatestMessages(ctx, []ConversationKey{key})
+	loadLatest := a.facts.LoadLatestMessages
+	if authoritative, ok := a.facts.(authoritativeMessageFactsStore); ok {
+		loadLatest = authoritative.LoadLatestMessagesAuthoritative
+	}
+	latestByKey, err := loadLatest(ctx, []ConversationKey{key})
 	if err != nil {
 		return 0, false, err
 	}

--- a/internal/usecase/conversation/unread_test.go
+++ b/internal/usecase/conversation/unread_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/WuKongIM/WuKongIM/pkg/channel"
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
 	"github.com/stretchr/testify/require"
 )
@@ -133,4 +134,49 @@ func TestSetUnreadDoesNotMoveReadSeqBackward(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Empty(t, repo.upsertedStates)
+}
+
+func TestSetUnreadUsesAuthoritativeLatestMessage(t *testing.T) {
+	base := newConversationSyncRepoStub()
+	base.latest[key("g1", 2)] = testMessage("g1", 2, 5, "u2", 100, "stale")
+	facts := &authoritativeConversationFactsStub{
+		conversationSyncRepoStub: base,
+		latest: map[ConversationKey]channel.Message{
+			key("g1", 2): testMessage("g1", 2, 10, "u2", 101, "leader"),
+		},
+	}
+	app := New(Options{
+		States: base,
+		Facts:  facts,
+	})
+
+	err := app.SetUnread(context.Background(), SetUnreadCommand{
+		UID:         "u1",
+		ChannelID:   "g1",
+		ChannelType: 2,
+		Unread:      3,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []ConversationKey{key("g1", 2)}, facts.loads)
+	require.Empty(t, base.latestLoads)
+	require.Len(t, base.upsertedStates, 1)
+	require.Equal(t, uint64(7), base.upsertedStates[0].ReadSeq)
+}
+
+type authoritativeConversationFactsStub struct {
+	*conversationSyncRepoStub
+	latest map[ConversationKey]channel.Message
+	loads  []ConversationKey
+}
+
+func (s *authoritativeConversationFactsStub) LoadLatestMessagesAuthoritative(_ context.Context, keys []ConversationKey) (map[ConversationKey]channel.Message, error) {
+	s.loads = append(s.loads, keys...)
+	out := make(map[ConversationKey]channel.Message, len(keys))
+	for _, key := range keys {
+		if msg, ok := s.latest[key]; ok {
+			out[key] = msg
+		}
+	}
+	return out, nil
 }

--- a/internal/usecase/conversation/unread_test.go
+++ b/internal/usecase/conversation/unread_test.go
@@ -16,9 +16,10 @@ func TestClearUnreadAdvancesReadSeqToLatestMessage(t *testing.T) {
 	repo.latest[key("g1", 2)] = testMessage("g1", 2, 10, "u2", 100, "c1")
 
 	app := New(Options{
-		States: repo,
-		Facts:  repo,
-		Now:    func() time.Time { return now },
+		States:             repo,
+		Facts:              repo,
+		AuthoritativeFacts: repo,
+		Now:                func() time.Time { return now },
 	})
 
 	err := app.ClearUnread(context.Background(), ClearUnreadCommand{
@@ -44,9 +45,10 @@ func TestClearUnreadUsesClientMessageSeqWhenLatestFactMissing(t *testing.T) {
 	repo := newConversationSyncRepoStub()
 
 	app := New(Options{
-		States: repo,
-		Facts:  repo,
-		Now:    func() time.Time { return now },
+		States:             repo,
+		Facts:              repo,
+		AuthoritativeFacts: repo,
+		Now:                func() time.Time { return now },
 	})
 
 	err := app.ClearUnread(context.Background(), ClearUnreadCommand{
@@ -83,9 +85,10 @@ func TestSetUnreadAdvancesReadSeqFromLatestMessage(t *testing.T) {
 	repo.latest[key("g1", 2)] = testMessage("g1", 2, 10, "u2", 100, "c1")
 
 	app := New(Options{
-		States: repo,
-		Facts:  repo,
-		Now:    func() time.Time { return now },
+		States:             repo,
+		Facts:              repo,
+		AuthoritativeFacts: repo,
+		Now:                func() time.Time { return now },
 	})
 
 	err := app.SetUnread(context.Background(), SetUnreadCommand{
@@ -121,8 +124,9 @@ func TestSetUnreadDoesNotMoveReadSeqBackward(t *testing.T) {
 	repo.latest[key("g1", 2)] = testMessage("g1", 2, 10, "u2", 100, "c1")
 
 	app := New(Options{
-		States: repo,
-		Facts:  repo,
+		States:             repo,
+		Facts:              repo,
+		AuthoritativeFacts: repo,
 	})
 
 	err := app.SetUnread(context.Background(), SetUnreadCommand{
@@ -146,8 +150,9 @@ func TestSetUnreadUsesAuthoritativeLatestMessage(t *testing.T) {
 		},
 	}
 	app := New(Options{
-		States: base,
-		Facts:  facts,
+		States:             base,
+		Facts:              base,
+		AuthoritativeFacts: facts,
 	})
 
 	err := app.SetUnread(context.Background(), SetUnreadCommand{
@@ -164,14 +169,54 @@ func TestSetUnreadUsesAuthoritativeLatestMessage(t *testing.T) {
 	require.Equal(t, uint64(7), base.upsertedStates[0].ReadSeq)
 }
 
+func TestSetUnreadFailsClosedWithoutAuthoritativeFacts(t *testing.T) {
+	repo := newConversationSyncRepoStub()
+	repo.latest[key("g1", 2)] = testMessage("g1", 2, 10, "u2", 100, "stale")
+	app := New(Options{States: repo, Facts: repo})
+
+	err := app.SetUnread(context.Background(), SetUnreadCommand{
+		UID:         "u1",
+		ChannelID:   "g1",
+		ChannelType: 2,
+		Unread:      0,
+	})
+
+	require.ErrorContains(t, err, "authoritative message facts store not configured")
+	require.Empty(t, repo.latestLoads)
+	require.Empty(t, repo.upsertedStates)
+}
+
+func TestSetUnreadDoesNotWriteWhenAuthoritativeReadFails(t *testing.T) {
+	base := newConversationSyncRepoStub()
+	facts := &authoritativeConversationFactsStub{
+		conversationSyncRepoStub: base,
+		err:                      channel.ErrNotReady,
+	}
+	app := New(Options{States: base, Facts: base, AuthoritativeFacts: facts})
+
+	err := app.SetUnread(context.Background(), SetUnreadCommand{
+		UID:         "u1",
+		ChannelID:   "g1",
+		ChannelType: 2,
+		Unread:      0,
+	})
+
+	require.ErrorIs(t, err, channel.ErrNotReady)
+	require.Empty(t, base.upsertedStates)
+}
+
 type authoritativeConversationFactsStub struct {
 	*conversationSyncRepoStub
 	latest map[ConversationKey]channel.Message
 	loads  []ConversationKey
+	err    error
 }
 
 func (s *authoritativeConversationFactsStub) LoadLatestMessagesAuthoritative(_ context.Context, keys []ConversationKey) (map[ConversationKey]channel.Message, error) {
 	s.loads = append(s.loads, keys...)
+	if s.err != nil {
+		return nil, s.err
+	}
 	out := make(map[ConversationKey]channel.Message, len(keys))
 	for _, key := range keys {
 		if msg, ok := s.latest[key]; ok {

--- a/pkg/channel/FLOW.md
+++ b/pkg/channel/FLOW.md
@@ -41,6 +41,7 @@ type Cluster interface {
 | `ReplicaState` | types.go | 副本状态：Role、运行时 CommitHW(`HW`)、持久化 CheckpointHW、`CommitReady`、LEO、Epoch、retention floor |
 | `AppendRequest` | types.go | 追加请求：ChannelID, Message, ExpectedChannelEpoch, ExpectedLeaderEpoch；`TraceID` / `Attempt` 仅用于节点内 diagnostics |
 | `AppendBatchRequest` | types.go | 同一 ChannelID 内按请求顺序追加多条消息；逐项结果与输入下标对齐，单条 `Append` 是其兼容包装 |
+| `FetchRequest` | types.go | 已提交消息读取请求；`RequireLeader=true` 时同时拒绝 follower 与 fenced former leader，仅供需要权威读语义的调用方使用 |
 | `Checkpoint` | types.go | 检查点：Epoch + LogStartOffset + HW；用于冷恢复下界与 reconcile 后的持久化提交水位 |
 | `RetentionView` / `RetentionReset` | types.go | retention 规划视图与 follower 低于逻辑 floor 时的 typed reset |
 | `FenceAndDrainRequest` / `DrainResult` | types.go | migration cutover 写栅栏下的 leader drain 请求与证明结果 |
@@ -101,7 +102,7 @@ Replica 层 (replica/append.go + replica/append_pipeline.go):
   ① 校验 Limit > 0, MaxBytes > 0
   ② 加载 Meta，检查频道状态非 Deleting/Deleted
   ③ 从 Runtime 获取 HandlerChannel → runtime.Channel(key)
-  ④ 若 `CommitReady=false`，直接返回 ErrNotReady，不再从 Checkpoint 猜 committed frontier
+  ④ `RequireLeader=true` 且本地副本不是当前 Leader 时返回 `ErrNotLeader`；若 `CommitReady=false`，返回 `ErrNotReady`，不再从 Checkpoint 猜 committed frontier
   ⑤ handler/fetch.go 将 `FromSeq=0` 或低于 retention/snapshot floor 的请求夹到 `MinAvailableSeq`
   ⑥ 直接调用 `message.ChannelStore.ListMessagesBySeq(startSeq, ...)` 扫描结构化 `message` 表
   ⑦ 读取结果按运行时 CommitHW 和 `MinAvailableSeq` 裁剪，不再通过 compat `ChannelStore.Read()` + DurableMessage 解码重建消息

--- a/pkg/channel/FLOW.md
+++ b/pkg/channel/FLOW.md
@@ -38,7 +38,7 @@ type Cluster interface {
 |------|------|------|
 | `Meta` | types.go | 频道元数据：Key, Epoch, RouteGeneration, Leader, Replicas, ISR, MinISR, LeaseUntil, Status, RetentionThroughSeq, WriteFence |
 | `Message` | types.go | 消息：MessageID, MessageSeq, FromUID, ClientMsgNo, Payload |
-| `ReplicaState` | types.go | 副本状态：Role、运行时 CommitHW(`HW`)、持久化 CheckpointHW、`CommitReady`、LEO、Epoch、retention floor |
+| `ReplicaState` | types.go | 副本状态：Role、Lease/WriteFence/DrainedFenceVersion、运行时 CommitHW(`HW`)、持久化 CheckpointHW、`CommitReady`、LEO、Epoch、retention floor |
 | `AppendRequest` | types.go | 追加请求：ChannelID, Message, ExpectedChannelEpoch, ExpectedLeaderEpoch；`TraceID` / `Attempt` 仅用于节点内 diagnostics |
 | `AppendBatchRequest` | types.go | 同一 ChannelID 内按请求顺序追加多条消息；逐项结果与输入下标对齐，单条 `Append` 是其兼容包装 |
 | `FetchRequest` | types.go | 已提交消息读取请求；`RequireLeader=true` 时同时拒绝 follower 与 fenced former leader，仅供需要权威读语义的调用方使用 |
@@ -102,7 +102,7 @@ Replica 层 (replica/append.go + replica/append_pipeline.go):
   ① 校验 Limit > 0, MaxBytes > 0
   ② 加载 Meta，检查频道状态非 Deleting/Deleted
   ③ 从 Runtime 获取 HandlerChannel → runtime.Channel(key)
-  ④ `RequireLeader=true` 且本地副本不是当前 Leader 时返回 `ErrNotLeader`；若 `CommitReady=false`，返回 `ErrNotReady`，不再从 Checkpoint 猜 committed frontier
+  ④ `RequireLeader=true` 时要求本地副本仍为 Leader、租约未过期且不存在 write/drain fence，否则返回 `ErrNotLeader`；若 `CommitReady=false`，返回 `ErrNotReady`，不再从 Checkpoint 猜 committed frontier
   ⑤ handler/fetch.go 将 `FromSeq=0` 或低于 retention/snapshot floor 的请求夹到 `MinAvailableSeq`
   ⑥ 直接调用 `message.ChannelStore.ListMessagesBySeq(startSeq, ...)` 扫描结构化 `message` 表
   ⑦ 读取结果按运行时 CommitHW 和 `MinAvailableSeq` 裁剪，不再通过 compat `ChannelStore.Read()` + DurableMessage 解码重建消息

--- a/pkg/channel/api_test.go
+++ b/pkg/channel/api_test.go
@@ -109,9 +109,10 @@ func TestNewBuildsClusterWithRuntimeHandlerAndTransport(t *testing.T) {
 	}
 
 	fetchResult, err := got.Fetch(context.Background(), channel.FetchRequest{
-		ChannelID: id,
-		Limit:     10,
-		MaxBytes:  1024,
+		ChannelID:     id,
+		Limit:         10,
+		MaxBytes:      1024,
+		RequireLeader: true,
 	})
 	if err != nil {
 		t.Fatalf("Fetch() error = %v", err)
@@ -623,6 +624,7 @@ func buildTestHandler(cfg channel.HandlerBuildConfig) (channel.MetaRollbackServi
 		Runtime:    rt,
 		Store:      engine,
 		MessageIDs: cfg.MessageIDs,
+		Now:        cfg.Now,
 	})
 }
 

--- a/pkg/channel/append_benchmark_test.go
+++ b/pkg/channel/append_benchmark_test.go
@@ -274,6 +274,7 @@ func newAppendBenchmarkEnv(b *testing.B, channelCount int, profile appendBenchma
 					Runtime:    buildCfg.Runtime,
 					Store:      buildCfg.Store.(*channelstore.Engine),
 					MessageIDs: buildCfg.MessageIDs,
+					Now:        buildCfg.Now,
 				})
 			},
 		},

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -140,6 +140,8 @@ type HandlerBuildConfig struct {
 	Store      any
 	Runtime    HandlerRuntime
 	MessageIDs MessageIDGenerator
+	// Now supplies the same clock used by the runtime for lease decisions.
+	Now func() time.Time
 }
 
 type cluster struct {
@@ -216,6 +218,7 @@ func New(cfg Config) (Cluster, error) {
 		Store:      cfg.Store,
 		Runtime:    runtimeValue,
 		MessageIDs: cfg.MessageIDs,
+		Now:        cfg.Now,
 	})
 	if err != nil {
 		return nil, joinBuildError(err, runtimeCloser(), transportCloser())

--- a/pkg/channel/handler/fetch.go
+++ b/pkg/channel/handler/fetch.go
@@ -34,6 +34,9 @@ func (s *service) Fetch(_ context.Context, req channel.FetchRequest) (channel.Fe
 		return channel.FetchResult{}, channel.ErrStaleMeta
 	}
 	state := group.Status()
+	if req.RequireLeader && state.Role != channel.ReplicaRoleLeader {
+		return channel.FetchResult{}, channel.ErrNotLeader
+	}
 	if !state.CommitReady {
 		return channel.FetchResult{}, channel.ErrNotReady
 	}

--- a/pkg/channel/handler/fetch.go
+++ b/pkg/channel/handler/fetch.go
@@ -35,6 +35,8 @@ func (s *service) Fetch(_ context.Context, req channel.FetchRequest) (channel.Fe
 	}
 	state := group.Status()
 	if req.RequireLeader {
+		// Authoritative reads deliberately fail closed on a zero lease,
+		// matching the replica append gate.
 		if state.Role != channel.ReplicaRoleLeader ||
 			!s.cfg.Now().Before(state.LeaseUntil) ||
 			meta.WriteFence.BlocksAppend() ||

--- a/pkg/channel/handler/fetch.go
+++ b/pkg/channel/handler/fetch.go
@@ -34,8 +34,14 @@ func (s *service) Fetch(_ context.Context, req channel.FetchRequest) (channel.Fe
 		return channel.FetchResult{}, channel.ErrStaleMeta
 	}
 	state := group.Status()
-	if req.RequireLeader && state.Role != channel.ReplicaRoleLeader {
-		return channel.FetchResult{}, channel.ErrNotLeader
+	if req.RequireLeader {
+		if state.Role != channel.ReplicaRoleLeader ||
+			!s.cfg.Now().Before(state.LeaseUntil) ||
+			meta.WriteFence.BlocksAppend() ||
+			state.WriteFence.BlocksAppend() ||
+			state.DrainedFenceVersion != 0 {
+			return channel.FetchResult{}, channel.ErrNotLeader
+		}
 	}
 	if !state.CommitReady {
 		return channel.FetchResult{}, channel.ErrNotReady

--- a/pkg/channel/handler/fetch_test.go
+++ b/pkg/channel/handler/fetch_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"testing"
+	"time"
 
 	core "github.com/WuKongIM/WuKongIM/pkg/channel"
 )
@@ -156,6 +157,85 @@ func TestFetchRequireLeaderRejectsFollower(t *testing.T) {
 	id := core.ChannelID{ID: "c1", Type: 1}
 	svc, rt, _ := newAppendService(t, id)
 	rt.channels[KeyFromChannelID(id)].status.Role = core.ReplicaRoleFollower
+
+	_, err := svc.Fetch(context.Background(), core.FetchRequest{
+		ChannelID:     id,
+		FromSeq:       1,
+		Limit:         1,
+		MaxBytes:      1024,
+		RequireLeader: true,
+	})
+	if err != core.ErrNotLeader {
+		t.Fatalf("expected ErrNotLeader, got %v", err)
+	}
+}
+
+func TestFetchRequireLeaderRejectsExpiredLease(t *testing.T) {
+	id := core.ChannelID{ID: "c1", Type: 1}
+	svc, rt, _ := newAppendService(t, id)
+	rt.channels[KeyFromChannelID(id)].status.LeaseUntil = time.Now().Add(-time.Second)
+
+	_, err := svc.Fetch(context.Background(), core.FetchRequest{
+		ChannelID:     id,
+		FromSeq:       1,
+		Limit:         1,
+		MaxBytes:      1024,
+		RequireLeader: true,
+	})
+	if err != core.ErrNotLeader {
+		t.Fatalf("expected ErrNotLeader, got %v", err)
+	}
+}
+
+func TestFetchRequireLeaderRejectsWriteFence(t *testing.T) {
+	id := core.ChannelID{ID: "c1", Type: 1}
+	svc, rt, _ := newAppendService(t, id)
+	rt.channels[KeyFromChannelID(id)].status.LeaseUntil = time.Now().Add(time.Minute)
+	raw := svc.(*service)
+	key := KeyFromChannelID(id)
+	raw.mu.Lock()
+	meta := raw.metas[key]
+	meta.WriteFence = core.WriteFence{Token: "migration", Version: 1}
+	raw.metas[key] = meta
+	raw.mu.Unlock()
+
+	_, err := svc.Fetch(context.Background(), core.FetchRequest{
+		ChannelID:     id,
+		FromSeq:       1,
+		Limit:         1,
+		MaxBytes:      1024,
+		RequireLeader: true,
+	})
+	if err != core.ErrNotLeader {
+		t.Fatalf("expected ErrNotLeader, got %v", err)
+	}
+}
+
+func TestFetchRequireLeaderRejectsRuntimeWriteFence(t *testing.T) {
+	id := core.ChannelID{ID: "c1", Type: 1}
+	svc, rt, _ := newAppendService(t, id)
+	handle := rt.channels[KeyFromChannelID(id)]
+	handle.status.LeaseUntil = time.Now().Add(time.Minute)
+	handle.status.WriteFence = core.WriteFence{Token: "migration", Version: 1}
+
+	_, err := svc.Fetch(context.Background(), core.FetchRequest{
+		ChannelID:     id,
+		FromSeq:       1,
+		Limit:         1,
+		MaxBytes:      1024,
+		RequireLeader: true,
+	})
+	if err != core.ErrNotLeader {
+		t.Fatalf("expected ErrNotLeader, got %v", err)
+	}
+}
+
+func TestFetchRequireLeaderRejectsDrainedReplica(t *testing.T) {
+	id := core.ChannelID{ID: "c1", Type: 1}
+	svc, rt, _ := newAppendService(t, id)
+	handle := rt.channels[KeyFromChannelID(id)]
+	handle.status.LeaseUntil = time.Now().Add(time.Minute)
+	handle.status.DrainedFenceVersion = 3
 
 	_, err := svc.Fetch(context.Background(), core.FetchRequest{
 		ChannelID:     id,

--- a/pkg/channel/handler/fetch_test.go
+++ b/pkg/channel/handler/fetch_test.go
@@ -152,6 +152,23 @@ func TestFetchReturnsNotReadyWhenCommitHWIsProvisional(t *testing.T) {
 	}
 }
 
+func TestFetchRequireLeaderRejectsFollower(t *testing.T) {
+	id := core.ChannelID{ID: "c1", Type: 1}
+	svc, rt, _ := newAppendService(t, id)
+	rt.channels[KeyFromChannelID(id)].status.Role = core.ReplicaRoleFollower
+
+	_, err := svc.Fetch(context.Background(), core.FetchRequest{
+		ChannelID:     id,
+		FromSeq:       1,
+		Limit:         1,
+		MaxBytes:      1024,
+		RequireLeader: true,
+	})
+	if err != core.ErrNotLeader {
+		t.Fatalf("expected ErrNotLeader, got %v", err)
+	}
+}
+
 func TestFetchMessagesFromStoreUsesStructuredScan(t *testing.T) {
 	st := &fakeFetchStore{
 		messages: []core.Message{

--- a/pkg/channel/handler/fetch_test.go
+++ b/pkg/channel/handler/fetch_test.go
@@ -170,6 +170,26 @@ func TestFetchRequireLeaderRejectsFollower(t *testing.T) {
 	}
 }
 
+func TestFetchRequireLeaderAcceptsHealthyLeader(t *testing.T) {
+	id := core.ChannelID{ID: "c1", Type: 1}
+	svc, rt, _ := newAppendService(t, id)
+	now := time.Unix(1700000000, 0)
+	raw := svc.(*service)
+	raw.cfg.Now = func() time.Time { return now }
+	rt.channels[KeyFromChannelID(id)].status.LeaseUntil = now.Add(time.Minute)
+
+	_, err := svc.Fetch(context.Background(), core.FetchRequest{
+		ChannelID:     id,
+		FromSeq:       1,
+		Limit:         1,
+		MaxBytes:      1024,
+		RequireLeader: true,
+	})
+	if err != nil {
+		t.Fatalf("Fetch() error = %v, want nil", err)
+	}
+}
+
 func TestFetchRequireLeaderRejectsExpiredLease(t *testing.T) {
 	id := core.ChannelID{ID: "c1", Type: 1}
 	svc, rt, _ := newAppendService(t, id)

--- a/pkg/channel/handler/meta.go
+++ b/pkg/channel/handler/meta.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/WuKongIM/WuKongIM/pkg/channel"
 	store "github.com/WuKongIM/WuKongIM/pkg/db/message"
@@ -12,6 +13,7 @@ type Config struct {
 	Runtime    channel.HandlerRuntime
 	Store      *store.Engine
 	MessageIDs channel.MessageIDGenerator
+	Now        func() time.Time
 }
 
 type Service interface{ channel.MetaRollbackService }
@@ -31,6 +33,9 @@ type service struct {
 func New(cfg Config) (Service, error) {
 	if cfg.Runtime == nil || cfg.Store == nil || cfg.MessageIDs == nil {
 		return nil, channel.ErrInvalidConfig
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
 	}
 	return &service{
 		cfg:                    cfg,

--- a/pkg/channel/handler/meta.go
+++ b/pkg/channel/handler/meta.go
@@ -13,7 +13,8 @@ type Config struct {
 	Runtime    channel.HandlerRuntime
 	Store      *store.Engine
 	MessageIDs channel.MessageIDGenerator
-	Now        func() time.Time
+	// Now supplies the clock used for authoritative leader-lease checks.
+	Now func() time.Time
 }
 
 type Service interface{ channel.MetaRollbackService }

--- a/pkg/channel/replica/append_test.go
+++ b/pkg/channel/replica/append_test.go
@@ -446,6 +446,7 @@ func TestFenceAndDrainRejectsNewAppends(t *testing.T) {
 	require.Equal(t, fenced.Key, drain.ChannelKey)
 	require.Equal(t, uint64(7), drain.ChannelEpoch)
 	require.Equal(t, uint64(1), drain.WriteFenceVersion)
+	require.Equal(t, uint64(1), r.Status().DrainedFenceVersion)
 
 	_, err = r.Append(context.Background(), []channel.Record{{Payload: []byte("x"), SizeBytes: 1}})
 	require.ErrorIs(t, err, channel.ErrWriteFenced)
@@ -786,16 +787,19 @@ func TestDrainedFailClosedReopensOnlyAfterNewerVersionClear(t *testing.T) {
 		ExpectedLeader:       1,
 	})
 	require.NoError(t, err)
+	require.Equal(t, uint64(1), r.Status().DrainedFenceVersion)
 
 	sameVersionClear := fenced
 	sameVersionClear.WriteFence = channel.WriteFence{Version: 1}
 	require.NoError(t, r.ApplyMeta(sameVersionClear))
+	require.Equal(t, uint64(1), r.Status().DrainedFenceVersion)
 	_, err = r.Append(channel.WithCommitMode(context.Background(), channel.CommitModeLocal), []channel.Record{{Payload: []byte("blocked"), SizeBytes: 7}})
 	require.ErrorIs(t, err, channel.ErrWriteFenced)
 
 	newerClear := fenced
 	newerClear.WriteFence = channel.WriteFence{Version: 2}
 	require.NoError(t, r.ApplyMeta(newerClear))
+	require.Zero(t, r.Status().DrainedFenceVersion)
 	_, err = r.Append(channel.WithCommitMode(context.Background(), channel.CommitModeLocal), []channel.Record{{Payload: []byte("open"), SizeBytes: 4}})
 	require.NoError(t, err)
 }

--- a/pkg/channel/replica/meta.go
+++ b/pkg/channel/replica/meta.go
@@ -34,11 +34,14 @@ func (r *replica) validateMetaLocked(normalized channel.Meta) error {
 func (r *replica) commitMetaLocked(normalized channel.Meta) {
 	if r.drainedFence.active && normalized.WriteFence.Version > r.drainedFence.version {
 		r.drainedFence = drainedFenceState{}
+		r.state.DrainedFenceVersion = 0
 	}
 	r.meta = normalized
 	r.state.ChannelKey = normalized.Key
 	r.state.Epoch = normalized.Epoch
 	r.state.Leader = normalized.Leader
+	r.state.LeaseUntil = normalized.LeaseUntil
+	r.state.WriteFence = normalized.WriteFence
 	if normalized.RetentionThroughSeq > r.state.RetentionThroughSeq {
 		r.state.RetentionThroughSeq = normalized.RetentionThroughSeq
 	}

--- a/pkg/channel/replica/meta_test.go
+++ b/pkg/channel/replica/meta_test.go
@@ -104,6 +104,7 @@ func TestApplyMetaLeaderLeaseRenewalDoesNotGateAppendsWhileCheckpointPending(t *
 
 	st := r.Status()
 	require.True(t, st.CommitReady)
+	require.Equal(t, renewed.LeaseUntil, st.LeaseUntil)
 	require.Equal(t, uint64(1), st.LEO)
 	require.Equal(t, uint64(1), st.HW)
 	require.Equal(t, uint64(0), st.CheckpointHW)

--- a/pkg/channel/replica/migration.go
+++ b/pkg/channel/replica/migration.go
@@ -77,6 +77,8 @@ func (r *replica) applyFenceAndDrainCommand(cmd machineFenceAndDrainCommand) mac
 		version: req.WriteFenceVersion,
 		active:  true,
 	}
+	r.state.DrainedFenceVersion = req.WriteFenceVersion
+	r.publishStateLocked()
 	drain := channel.DrainResult{
 		ChannelKey:        r.state.ChannelKey,
 		LEO:               r.state.LEO,

--- a/pkg/channel/types.go
+++ b/pkg/channel/types.go
@@ -299,16 +299,23 @@ const (
 )
 
 type ReplicaState struct {
-	ChannelKey     ChannelKey
-	Role           ReplicaRole
-	Epoch          uint64
-	OffsetEpoch    uint64
-	Leader         NodeID
-	LogStartOffset uint64
-	HW             uint64
-	CheckpointHW   uint64
-	CommitReady    bool
-	LEO            uint64
+	ChannelKey  ChannelKey
+	Role        ReplicaRole
+	Epoch       uint64
+	OffsetEpoch uint64
+	Leader      NodeID
+	// LeaseUntil is the locally applied leadership lease deadline.
+	LeaseUntil time.Time
+	// WriteFence is the locally applied authoritative write fence.
+	WriteFence WriteFence
+	// DrainedFenceVersion is non-zero after this replica has produced a stable
+	// migration drain proof and until newer authoritative metadata clears it.
+	DrainedFenceVersion uint64
+	LogStartOffset      uint64
+	HW                  uint64
+	CheckpointHW        uint64
+	CommitReady         bool
+	LEO                 uint64
 	// RetentionThroughSeq is the local logical retention fence applied from metadata.
 	RetentionThroughSeq uint64
 	// MinAvailableSeq is the first message sequence that reads may return.

--- a/pkg/channel/types.go
+++ b/pkg/channel/types.go
@@ -215,6 +215,8 @@ type FetchRequest struct {
 	MaxBytes             int
 	ExpectedChannelEpoch uint64
 	ExpectedLeaderEpoch  uint64
+	// RequireLeader rejects reads from followers and fenced former leaders.
+	RequireLeader bool
 }
 
 type FetchResult struct {


### PR DESCRIPTION
## Summary

- resolve conversation read-cursor mutations through a leader-required, epoch-fenced read
- invalidate stale routing and retry once after leader, metadata, or transport failures
- reject authoritative reads from followers, lease-expired leaders, write-fenced leaders, and drained former leaders
- use non-bootstrapping metadata activation so unknown client channel IDs cannot create runtime metadata
- return HTTP 503 with a stable retry response for transient cluster and mixed-version peer failures
- keep ordinary conversation sync best-effort and preserve local/remote deleted-channel parity

## Why

In a multi-node deployment, the UID-owner node handling `clearUnread` or `setUnread` may not be the current channel leader. A readable follower can be `CommitReady` while lagging the leader, so its high-watermark is not authoritative for a read cursor.

The authoritative path now carries expected channel and leader epochs and requires the serving replica to prove that it is still a writable leader: the role must be leader, its lease must be live, and no metadata, runtime, or completed-drain fence may be active. A stale or unreachable route is invalidated and resolved once more before returning a retryable failure.

## Scope

The authoritative path is used by:

- `ClearUnread`
- `SetUnread`
- `DeleteConversation` when `message_seq` is zero

Requester- and serving-side route refreshes use fetch/probe activation rather than business activation. Missing channels therefore return `ErrChannelNotFound` without bootstrapping persistent channel metadata. A first message that commits between `Status` and the fenced `Fetch` is accepted from the fetch result instead of being discarded by the older status snapshot.

## Error behavior

`NotLeader`, `NoLeader`, `StaleMeta`, `NotReady`, metadata-authority failures, and unknown peer transport failures remain fail-closed. Metadata and peer routing failures invalidate the cached route and retry once. Mutation APIs translate unresolved transient failures to:

    HTTP 503
    {"msg":"retry required","status":503}

During a rolling upgrade, an older peer that does not understand the authoritative conversation-facts codec is also treated as temporarily not ready. The caller never falls back to an unfenced legacy read.

Known permanent channel states use stable responses (`404 channel not found`, `409 channel deleting`). Any unclassified internal failure is logged and returned as a generic HTTP 500; internal network or cluster details are never echoed to clients.

## Compatibility

- ordinary latest/recent conversation reads retain their existing best-effort behavior
- authoritative requests use the version-2 conversation-facts codec; ordinary requests remain version 1
- single-node deployments use the same fenced local-leader path without self-dialing RPC
- deleted channels are treated as empty on both local- and remote-leader paths

## Verification

- `go test ./...`
- `go test -run '^$' ./...`
- `go vet ./...`
- focused tests cover route refresh after metadata-authority and peer-transport failures; stable non-leaking HTTP error mapping; lease, handler/runtime write-fence, and drain rejection; a healthy-leader positive path with an injected clock; requester/serving non-bootstrapping activation; local/remote deleted-channel parity; first-message commit races; follower rejection; epoch fencing; mixed-version peers; and local-leader reads
