### PR TITLE
fix: route metadata proposals from non-replica nodes

### DIFF
--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -1,5 +1,6 @@
 # Code Quality Notes
 
+- `pkg/transport.Server.serveConn` captures `mc` in a dispatch closure while `newMuxConn` starts the reader before assigning `mc`; the reader can race with that assignment (`server.go:149/151`). Reproduced on unchanged main `613fc2b2` with `go test -race ./pkg/cluster -run '^TestForwardToLeader_RoundTrip$' -count=20`. Track separately from non-replica proposal routing; network-backed race tests are not clean until connection publication is synchronized.
 - `TestSendStressThreeNode` can finish all sends and durable verification, then fail during `t.Cleanup` because `App.Stop()` uses one shared 5s stop context for every lifecycle component; under stress, late cluster RPC retries can consume the budget and surface as `context deadline exceeded`. Consider per-component shutdown budgets or clearer cleanup diagnostics.
 - `pkg/channel/runtime.TestSessionLongPollRPCTimeoutUsesRecoveryBackoff` failed once during a broad package run with `long poll timeout should not immediately retry, got 2 sends`, then passed with `-run ... -count=5` and a fresh package run. The test appears timing-sensitive and should use deterministic scheduler hooks instead of wall-clock assumptions.
 - `internal/app/deliveryrouting.go:isSenderDeliveryRoute` contains a duplicated return statement. It is harmless but should be cleaned up in a separate readability pass.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -137,6 +137,7 @@
 - Large Slot Raft snapshots are chunked only in `pkg/cluster` raft transport; receivers reassemble chunks into the original `MsgSnap` before calling `multiraft.Runtime.Step`.
 
 ### Local storage
+- Slot metadata proposals must route from non-replica ingress nodes using global assignments and observed/probed leaders. `Cluster.LeaderOf` and `ProposeLocalWithHashSlot` remain local-only; normalize missing-runtime errors to cluster `ErrSlotNotFound` so local leader scans can skip them.
 - `pkg/db` is the single local storage library: `message` owns channel logs and `meta` owns hash-slot metadata.
 - Ordinary new `pkg/db/meta` tables should use the meta table runtime registry; custom code is reserved for cache, guard, monotonic, or multi-record state-machine semantics.
 - A single-node deployment is still a single-node cluster; do not add storage or business paths that bypass cluster semantics.

--- a/internal/access/api/nonreplica_token_integration_test.go
+++ b/internal/access/api/nonreplica_token_integration_test.go
@@ -1,0 +1,180 @@
+//go:build integration
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/internal/usecase/user"
+	raftcluster "github.com/WuKongIM/WuKongIM/pkg/cluster"
+	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
+	raftstorage "github.com/WuKongIM/WuKongIM/pkg/raftlog"
+	metafsm "github.com/WuKongIM/WuKongIM/pkg/slot/fsm"
+	"github.com/WuKongIM/WuKongIM/pkg/slot/multiraft"
+	"github.com/WuKongIM/WuKongIM/pkg/slot/proxy"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTokenOnNonReplicaNodes exercises the real HTTP -> user -> proxy -> Raft
+// path with fresh databases, including nodes with no local runtime for the UID.
+func TestTokenOnNonReplicaNodes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
+	defer cancel()
+	configs := make([]raftcluster.NodeConfig, 5)
+	listeners := make([]net.Listener, len(configs))
+	for i := range configs {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = ln.Close() })
+		listeners[i] = ln
+		configs[i] = raftcluster.NodeConfig{NodeID: multiraft.NodeID(i + 1), Addr: ln.Addr().String()}
+	}
+	for _, ln := range listeners {
+		require.NoError(t, ln.Close())
+	}
+	clusters := make([]*raftcluster.Cluster, len(configs))
+	stores := make([]*proxy.Store, len(configs))
+	servers := make([]*Server, len(configs))
+	for i := range configs {
+		dir := t.TempDir()
+		db, err := metadb.Open(filepath.Join(dir, "meta"))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, db.Close()) })
+		raftDB, err := raftstorage.Open(filepath.Join(dir, "raft"), raftstorage.Options{})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, raftDB.Close()) })
+		c, err := raftcluster.NewCluster(raftcluster.Config{
+			NodeID: configs[i].NodeID, ListenAddr: configs[i].Addr, Nodes: configs,
+			SlotCount: 10, InitialSlotCount: 10, HashSlotCount: 64,
+			ControllerReplicaN: 3, SlotReplicaN: 3, RaftWorkers: 1,
+			ControllerMetaPath:           filepath.Join(dir, "controller-meta"),
+			ControllerRaftPath:           filepath.Join(dir, "controller-raft"),
+			NewStorage:                   func(id multiraft.SlotID) (multiraft.Storage, error) { return raftDB.ForSlot(uint64(id)), nil },
+			NewStateMachine:              metafsm.NewStateMachineFactory(db),
+			NewStateMachineWithHashSlots: metafsm.NewHashSlotStateMachineFactory(db),
+		})
+		require.NoError(t, err)
+		clusters[i] = c
+		stores[i] = proxy.New(c, db)
+		servers[i] = New(Options{Users: user.New(user.Options{Users: stores[i], Devices: stores[i]})})
+		require.NoError(t, c.Start())
+		t.Cleanup(c.Stop)
+	}
+	uid := "nonreplica-token-existing-user"
+	slotID := clusters[0].SlotForKey(uid)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		for _, c := range clusters {
+			t.Logf("node=%d listen=%s controller=%d assignments=%v", c.NodeID(), c.Server().Listener().Addr(), c.ControllerLeaderID(), c.ListCachedAssignments())
+			for _, id := range c.SlotIDs() {
+				leader, err := c.LeaderOf(id)
+				t.Logf("node=%d slot=%d peers=%v leader=%d error=%v", c.NodeID(), id, c.PeersForSlot(id), leader, err)
+			}
+		}
+	})
+	var peers []multiraft.NodeID
+	require.Eventually(t, func() bool {
+		peers = clusters[0].PeersForSlot(slotID)
+		if len(peers) != 3 {
+			return false
+		}
+		for _, c := range clusters {
+			if !slices.Equal(c.PeersForSlot(slotID), peers) {
+				return false
+			}
+			for _, id := range c.SlotIDs() {
+				if slices.Contains(c.PeersForSlot(id), c.NodeID()) {
+					if _, err := c.LeaderOf(id); err != nil {
+						return false
+					}
+				}
+			}
+		}
+		return true
+	}, 120*time.Second, 100*time.Millisecond)
+	require.Len(t, peers, 3)
+	postToken := func(node int, uid, token string) {
+		t.Helper()
+		body := fmt.Sprintf(`{"uid":%q,"token":%q,"device_flag":1,"device_level":1}`, uid, token)
+		req := httptest.NewRequest(http.MethodPost, "/user/token", strings.NewReader(body)).WithContext(ctx)
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		servers[node].Engine().ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code, "node=%d body=%s", node+1, resp.Body.String())
+		require.JSONEq(t, `{"status":200}`, resp.Body.String())
+	}
+	// Register on a replica, then update the same account on every ingress node.
+	postToken(int(peers[0])-1, uid, "registered")
+	nonreplicas := 0
+	for i, c := range clusters {
+		require.Equal(t, peers, c.PeersForSlot(slotID))
+		token := fmt.Sprintf("token-from-node-%d", c.NodeID())
+		postToken(i, uid, token)
+		if !slices.Contains(peers, c.NodeID()) {
+			nonreplicas++
+			_, err := c.LeaderOf(slotID)
+			require.ErrorIs(t, err, raftcluster.ErrSlotNotFound)
+			require.ErrorIs(t, c.ProposeLocalWithHashSlot(ctx, slotID, c.HashSlotForKey(uid), nil), raftcluster.ErrSlotNotFound)
+		}
+		for _, store := range stores {
+			device, err := store.GetDevice(ctx, uid, 1)
+			require.NoError(t, err)
+			require.Equal(t, token, device.Token)
+		}
+		// Fresh registration also needs CreateUser to route off a non-replica.
+		freshUID := ""
+		for suffix := 0; suffix < 10000; suffix++ {
+			candidate := fmt.Sprintf("fresh-node-%d-%d", i+1, suffix)
+			if c.SlotForKey(candidate) == slotID {
+				freshUID = candidate
+				break
+			}
+		}
+		require.NotEmpty(t, freshUID, "find a fresh UID in the same slot")
+		postToken(i, freshUID, "fresh-token")
+		// Local leader scans must skip absent slots, not fail or scan remotely.
+		_, err := stores[i].ListRunnableChannelMigrationTasksForLocalLeaderSlots(ctx, time.Now().UnixMilli(), 100)
+		require.NoError(t, err)
+	}
+	require.Equal(t, 2, nonreplicas)
+
+	// Move the actual Raft leader, then write through both non-replicas again.
+	// The caller does not refresh or inject a leader into the routing layer.
+	oldLeader, err := clusters[int(peers[0])-1].LeaderOf(slotID)
+	require.NoError(t, err)
+	newLeader := peers[0]
+	if newLeader == oldLeader {
+		newLeader = peers[1]
+	}
+	transferCtx, transferCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer transferCancel()
+	require.NoError(t, clusters[int(oldLeader)-1].TransferSlotLeader(transferCtx, uint32(slotID), newLeader))
+	require.Eventually(t, func() bool {
+		leader, err := clusters[int(newLeader)-1].LeaderOf(slotID)
+		return err == nil && leader == newLeader
+	}, 10*time.Second, 20*time.Millisecond)
+	for i, c := range clusters {
+		if slices.Contains(peers, c.NodeID()) {
+			continue
+		}
+		token := fmt.Sprintf("after-transfer-node-%d", c.NodeID())
+		postToken(i, uid, token)
+		for _, store := range stores {
+			device, err := store.GetDevice(ctx, uid, 1)
+			require.NoError(t, err)
+			require.Equal(t, token, device.Token)
+		}
+	}
+	t.Logf("slot=%d peers=%v leader=%d->%d: 7 token updates / 35 authoritative reads / 5 fresh registrations / 5 local scans", slotID, peers, oldLeader, newLeader)
+}

--- a/pkg/cluster/FLOW.md
+++ b/pkg/cluster/FLOW.md
@@ -158,7 +158,10 @@ Start():
 ProposeWithHashSlot:
   ③ encodeProposalPayload(hashSlot, cmd)  // 在 cmd 前附加 2 字节 hashSlot
   ④ Retry 循环 (ForwardRetryBudget 预算内):
-     a. router.LeaderOf(slotID) → 查询本地 Runtime 的 Leader
+     a. resolveProposalLeader(slotID):
+        → 优先本地 Runtime 的 leader 观测
+        → 本机无槽/无 leader 时，使用现有 observation cache 中当前 assignment 内、epoch/时间有效的 leader hint
+        → 无有效 hint 或上次提案被拒绝时，按全局 PeersForSlot 向副本发送 managed-slot status RPC，确认目标自身为 leader
      b. 本地 Leader:
         runtime.Propose(ctx, slotID, payload) → future.Wait(ctx)
      c. 远程 Leader:
@@ -168,7 +171,9 @@ ProposeWithHashSlot:
              decodeForwardPayload → runtime.Status(验证 Slot 存在)
              → runtime.Propose → future.Wait
              → encodeForwardResp(errCode, data)
-          → 解码响应: OK / NotLeader(重试) / Timeout / NoSlot
+          → 解码响应: OK / NotLeader / Timeout / NoSlot
+     d. NotLeader / 转发 NoSlot → 绕过旧 hint、重新探测；无 leader 可在剩余预算内重试
+        网络/提交 Timeout 不自动重放；Raft runtime 始终校验最终提案，观测不代替写入权限
   ⑤ 返回结果 (通过 ObserverHooks.OnForwardPropose 上报)
 ```
 
@@ -578,7 +583,8 @@ SlotIDs()/planner/readiness:
 ## 8. 避坑清单
 
 - **Propose 必须带 HashSlot**: `Propose()` 是兼容旧路径的快捷方式，仅适用于"一个物理 Slot 只有一个 Hash Slot"的场景。一旦 Slot 拥有多个 Hash Slot（AddSlot/Rebalance 后），必须使用 `ProposeWithHashSlot`，否则返回 `ErrHashSlotRequired`。
-- **Forward 重试预算有限**: `ProposeWithHashSlot` 内置 Retry 循环，`ForwardRetryBudget`(默认 300ms) 只重试 `ErrNotLeader`。网络分区或全部 peer 不可达时不会无限重试。
+- **全局写入与本地检查分离**: `ProposeWithHashSlot[Result]` 可以从非副本节点寻址并转发；`LeaderOf`、`ProposeLocalWithHashSlot` 仍只检查本机 runtime，非副本统一返回 cluster `ErrSlotNotFound`，以便本地 leader 扫描跳过无槽节点。
+- **Forward 重试预算有限**: `ForwardRetryBudget`（默认 300ms）限制 leader 探测和重路由，即使调用者 deadline 更长也不会无限重试；单 peer 只分得剩余探测预算的一部分。已发出的提案保留原有调用者 deadline 语义，网络/提交超时不自动重放。只将 `ErrNotLeader`、转发 `NoSlot`、探测无 leader 作为重路由信号，未知槽直接失败。
 - **Controller 观测读语义**: `ListObservedRuntimeViews` 在 leader 上优先读本地 `observationCache`；只有 leader 不可达时才允许降级到本地 `controllerMeta`，且结果可能滞后。
 - **Manager 严格一致读语义**: `ListNodesStrict`、`ListSlotAssignmentsStrict`、`ListObservedRuntimeViewsStrict`、`ListTasksStrict`、`GetReconcileTaskStrict` 只接受 controller leader 结果；本地节点若自身就是 leader 可直接读 leader 本地数据，否则必须经 controller client 读取，禁止降级到本地 `controllerMeta`。
 - **Manager Slot 日志读语义**: `SlotLogStatusOnNode` 只读取目标节点当前 Slot Raft 运行时的 commit/applied watermark；`SlotLogEntriesOnNode` 只读取目标节点本地 Slot storage 的 Raft log entry 摘要页（index/term/type/data_size），并对普通 Slot FSM command payload 生成脱敏 JSON inspection（如 command/uid/channel_id，token 固定为 `***`）。二者都用于运维排查，不能替代 controller leader strict-read 拓扑来源。

--- a/pkg/cluster/api.go
+++ b/pkg/cluster/api.go
@@ -20,6 +20,7 @@ type API interface {
 	HashSlotsOf(slotID multiraft.SlotID) []uint16
 	HashSlotTableVersion() uint64
 	ControllerLeaderID() uint64
+	// LeaderOf reads the local runtime; non-replicas return ErrSlotNotFound.
 	LeaderOf(slotID multiraft.SlotID) (multiraft.NodeID, error)
 	Propose(ctx context.Context, slotID multiraft.SlotID, cmd []byte) error
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -985,18 +985,29 @@ func (c *Cluster) ProposeWithHashSlotResult(ctx context.Context, slotID multiraf
 		proposeErr = ErrNotStarted
 		return nil, proposeErr
 	}
+	// Bound discovery and rerouting even when the caller has a longer deadline.
+	// Keep the caller's existing deadline semantics for an in-flight proposal.
+	routeDeadline := start.Add(c.timeoutConfig().ForwardRetryBudget)
+	refreshLeader := false
 	retry := Retry{
 		Interval: c.forwardRetryInterval(),
 		MaxWait:  c.timeoutConfig().ForwardRetryBudget,
 		IsRetryable: func(err error) bool {
-			return errors.Is(err, ErrNotLeader)
+			return time.Now().Before(routeDeadline) && (errors.Is(err, ErrNotLeader) || errors.Is(err, ErrNoLeader))
 		},
 	}
 	var data []byte
-	proposeErr = retry.Do(ctx, func(attemptCtx context.Context) error {
+	proposeErr = retry.Do(ctx, func(attemptCtx context.Context) (attemptErr error) {
 		attempts++
+		defer func() {
+			if errors.Is(attemptErr, ErrNotLeader) {
+				refreshLeader = true
+			}
+		}()
 		payload := encodeProposalPayload(hashSlot, cmd)
-		leaderID, err := c.router.LeaderOf(slotID)
+		routeCtx, cancel := context.WithDeadline(attemptCtx, routeDeadline)
+		leaderID, err := c.resolveProposalLeader(routeCtx, slotID, refreshLeader)
+		cancel()
 		if err != nil {
 			return err
 		}
@@ -1005,6 +1016,9 @@ func (c *Cluster) ProposeWithHashSlotResult(ctx context.Context, slotID multiraf
 			if err != nil {
 				err = normalizeProposeError(err)
 				c.notifyProposeLocalErrorForTest(err)
+				if errors.Is(err, ErrSlotNotFound) {
+					return errors.Join(ErrNotLeader, err)
+				}
 				return err
 			}
 			result, err := future.Wait(attemptCtx)
@@ -1018,6 +1032,9 @@ func (c *Cluster) ProposeWithHashSlotResult(ctx context.Context, slotID multiraf
 		}
 		result, err := c.forwardToLeaderResult(attemptCtx, leaderID, slotID, payload)
 		if err != nil {
+			if errors.Is(err, ErrSlotNotFound) {
+				return errors.Join(ErrNotLeader, err)
+			}
 			return err
 		}
 		data = append(data[:0], result...)
@@ -1063,6 +1080,9 @@ func (c *Cluster) notifyProposeLocalErrorForTest(err error) {
 func normalizeProposeError(err error) error {
 	if errors.Is(err, multiraft.ErrNotLeader) {
 		return ErrNotLeader
+	}
+	if errors.Is(err, multiraft.ErrSlotNotFound) {
+		return ErrSlotNotFound
 	}
 	return err
 }
@@ -1325,7 +1345,9 @@ func (c *Cluster) updateRegisteredStateMachineFromHashSlotTable(slotID multiraft
 	}
 }
 
-// LeaderOf returns the current leader of the specified slot.
+// LeaderOf returns the leader observed by the local slot runtime, or
+// ErrSlotNotFound on a non-replica. Cluster-wide proposals resolve remote slots
+// separately; local-only guards must not use global routing hints.
 func (c *Cluster) LeaderOf(slotID multiraft.SlotID) (multiraft.NodeID, error) {
 	if c == nil || c.router == nil {
 		return 0, ErrNotStarted

--- a/pkg/cluster/proposal_route.go
+++ b/pkg/cluster/proposal_route.go
@@ -1,0 +1,114 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/pkg/slot/multiraft"
+)
+
+// resolveProposalLeader separates cluster-wide write routing from local runtime
+// ownership checks. Observations are hints only: the target Raft runtime still
+// validates every proposal. A rejected hint is bypassed on the next attempt.
+func (c *Cluster) resolveProposalLeader(ctx context.Context, slotID multiraft.SlotID, refresh bool) (multiraft.NodeID, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	leader, err := c.router.LeaderOf(slotID)
+	if err == nil && (!refresh || c.IsLocal(leader)) {
+		return leader, nil
+	}
+	if err != nil && !errors.Is(err, ErrSlotNotFound) && !errors.Is(err, ErrNoLeader) {
+		return 0, err
+	}
+	peers := c.PeersForSlot(slotID)
+	if len(peers) == 0 {
+		return 0, ErrSlotNotFound
+	}
+	if !refresh {
+		if leader := c.observedProposalLeader(slotID, peers); leader != 0 {
+			return leader, nil
+		}
+	}
+
+	// Probe only this slot's replicas, not every slot or the controller. Divide
+	// the remaining discovery budget so an unavailable peer cannot consume it all.
+	visited := make(map[multiraft.NodeID]bool, len(peers))
+	targets := append([]multiraft.NodeID(nil), peers...)
+	var lastErr error
+	for len(targets) > 0 {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		target := targets[0]
+		targets = targets[1:]
+		if target == 0 || visited[target] {
+			continue
+		}
+		visited[target] = true
+		probeBudget := c.timeoutConfig().ForwardRetryBudget
+		if deadline, ok := ctx.Deadline(); ok {
+			probeBudget = time.Until(deadline)
+		}
+		probeBudget /= time.Duration(len(peers) - len(visited) + 1)
+		probeCtx, cancel := context.WithTimeout(ctx, probeBudget)
+		status, err := c.managedSlots().statusOnNode(probeCtx, target, slotID)
+		cancel()
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		leader := status.LeaderID
+		if leader == 0 || !nodeIDsContain(peers, leader) || !nodeIDsContain(status.CurrentVoters, leader) {
+			continue
+		}
+		// Confirm the leader on the node itself; a follower may retain an old
+		// leader observation. Never substitute DesiredPeers[0]/PreferredLeader.
+		if leader == target {
+			return leader, nil
+		}
+		if !visited[leader] {
+			targets = append([]multiraft.NodeID{leader}, targets...)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if lastErr != nil {
+		return 0, fmt.Errorf("resolve slot %d leader: %w", slotID, errors.Join(ErrNoLeader, lastErr))
+	}
+	return 0, ErrNoLeader
+}
+
+// observedProposalLeader uses the existing point-indexed observation cache as
+// a fast routing hint. It neither performs controller RPC nor scans all slots.
+func (c *Cluster) observedProposalLeader(slotID multiraft.SlotID, peers []multiraft.NodeID) multiraft.NodeID {
+	a := c.agent
+	if a == nil {
+		return 0
+	}
+	a.observationMu.RLock()
+	view, ok := a.observationState.RuntimeViews[uint32(slotID)]
+	generation := a.observationState.LeaderGeneration
+	controllerLeader := a.observationState.LeaderID
+	a.observationMu.RUnlock()
+	knownControllerLeader := c.ControllerLeaderID()
+	if !ok || view.SlotID != uint32(slotID) || generation == 0 || controllerLeader == 0 ||
+		(knownControllerLeader != 0 && controllerLeader != knownControllerLeader) {
+		return 0
+	}
+	leader := multiraft.NodeID(view.LeaderID)
+	if leader == 0 || !nodeIDsContain(peers, leader) || !assignmentContainsPeer(view.CurrentVoters, view.LeaderID) {
+		return 0
+	}
+	age := time.Since(view.LastReportAt)
+	if view.LastReportAt.IsZero() || age < 0 || age > c.timeoutConfig().ObservationRuntimeFullSyncInterval {
+		return 0
+	}
+	if epoch, ok := c.assignments.ConfigEpochForSlot(slotID); ok && view.ObservedConfigEpoch < epoch {
+		return 0
+	}
+	return leader
+}

--- a/pkg/cluster/proposal_route_test.go
+++ b/pkg/cluster/proposal_route_test.go
@@ -1,0 +1,257 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	controllermeta "github.com/WuKongIM/WuKongIM/pkg/controller/meta"
+	"github.com/WuKongIM/WuKongIM/pkg/slot/multiraft"
+	"github.com/WuKongIM/WuKongIM/pkg/transport"
+	"github.com/stretchr/testify/require"
+)
+
+type proposalRouteTestHandler func(context.Context, uint8, []byte) ([]byte, error)
+
+func newProposalRouteTestCluster(t *testing.T, handlers map[multiraft.NodeID]proposalRouteTestHandler) *Cluster {
+	t.Helper()
+	rt, err := multiraft.New(multiraft.Options{
+		NodeID: 1, TickInterval: 10 * time.Millisecond, Workers: 1, Transport: observerTestTransport{},
+		Raft: multiraft.RaftOptions{ElectionTick: 3, HeartbeatTick: 1},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rt.Close()) })
+	var nodes []NodeConfig
+	for id, handler := range handlers {
+		srv := transport.NewServer()
+		mux := transport.NewRPCMux()
+		for _, service := range []uint8{rpcServiceForward, rpcServiceManagedSlot} {
+			mux.Handle(service, func(ctx context.Context, body []byte) ([]byte, error) { return handler(ctx, service, body) })
+		}
+		srv.HandleRPCMux(mux)
+		require.NoError(t, srv.Start("127.0.0.1:0"))
+		t.Cleanup(srv.Stop)
+		nodes = append(nodes, NodeConfig{NodeID: id, Addr: srv.Listener().Addr().String()})
+	}
+	pool := transport.NewPool(NewStaticDiscovery(nodes), 2, time.Second)
+	t.Cleanup(pool.Close)
+	client := transport.NewClient(pool)
+	t.Cleanup(client.Stop)
+	c := &Cluster{
+		cfg: Config{NodeID: 1}, runtime: rt, router: NewRouter(NewHashSlotTable(4, 1), 1, rt),
+		transportResources: transportResources{fwdClient: client},
+		agentResources:     agentResources{assignments: newAssignmentCache()},
+	}
+	c.slotMgr = newSlotManager(c)
+	c.assignments.SetAssignments([]controllermeta.SlotAssignment{{SlotID: 1, DesiredPeers: []uint64{2, 3}, ConfigEpoch: 1}})
+	return c
+}
+
+func proposalRouteTestStatus(leader uint64) ([]byte, error) {
+	return encodeManagedSlotResponse(managedSlotRPCResponse{LeaderID: leader, CurrentVoters: []uint64{2, 3}})
+}
+
+func setProposalRouteTestObservation(c *Cluster, view controllermeta.SlotRuntimeView) {
+	c.agent = &slotAgent{observationState: observationAppliedState{
+		LeaderID: 2, LeaderGeneration: 1,
+		RuntimeViews: map[uint32]controllermeta.SlotRuntimeView{1: view},
+	}}
+}
+
+func TestProposalRoutesWithoutLocalReplica(t *testing.T) {
+	var writes atomic.Int32
+	c := newProposalRouteTestCluster(t, map[multiraft.NodeID]proposalRouteTestHandler{
+		2: func(_ context.Context, service uint8, _ []byte) ([]byte, error) {
+			if service != rpcServiceManagedSlot {
+				return nil, errors.New("must not propose to follower")
+			}
+			return proposalRouteTestStatus(3)
+		},
+		3: func(_ context.Context, service uint8, body []byte) ([]byte, error) {
+			if service == rpcServiceManagedSlot {
+				return proposalRouteTestStatus(3)
+			}
+			writes.Add(1)
+			slot, payload, err := decodeForwardPayload(body)
+			if err != nil || slot != 1 || string(payload) != string(encodeProposalPayload(2, []byte("command"))) {
+				return nil, errors.New("lost slot/hash-slot proposal envelope")
+			}
+			return encodeForwardResp(errCodeOK, []byte("applied-result")), nil
+		},
+	})
+	result, err := c.ProposeWithHashSlotResult(context.Background(), 1, 2, []byte("command"))
+	require.NoError(t, err)
+	require.Equal(t, "applied-result", string(result))
+	require.EqualValues(t, 1, writes.Load())
+	_, err = c.LeaderOf(1)
+	require.ErrorIs(t, err, ErrSlotNotFound)
+	require.ErrorIs(t, c.ProposeLocalWithHashSlot(context.Background(), 1, 2, nil), ErrSlotNotFound)
+	require.EqualValues(t, 1, writes.Load(), "local-only proposal must not forward")
+	require.ErrorIs(t, c.ProposeWithHashSlot(context.Background(), 99, 2, nil), ErrSlotNotFound)
+}
+
+func TestProposalRefreshesRejectedObservation(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		code byte
+	}{
+		{"not_leader", errCodeNotLeader}, {"no_slot", errCodeNoSlot},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var oldWrites, newWrites atomic.Int32
+			c := newProposalRouteTestCluster(t, map[multiraft.NodeID]proposalRouteTestHandler{
+				2: func(_ context.Context, service uint8, _ []byte) ([]byte, error) {
+					if service == rpcServiceManagedSlot {
+						return proposalRouteTestStatus(3)
+					}
+					oldWrites.Add(1)
+					return encodeForwardResp(test.code, nil), nil
+				},
+				3: func(_ context.Context, service uint8, _ []byte) ([]byte, error) {
+					if service == rpcServiceManagedSlot {
+						return proposalRouteTestStatus(3)
+					}
+					newWrites.Add(1)
+					return encodeForwardResp(errCodeOK, []byte("new-leader")), nil
+				},
+			})
+			setProposalRouteTestObservation(c, controllermeta.SlotRuntimeView{
+				SlotID: 1, LeaderID: 2, CurrentVoters: []uint64{2, 3}, ObservedConfigEpoch: 1, LastReportAt: time.Now(),
+			})
+			result, err := c.ProposeWithHashSlotResult(context.Background(), 1, 2, nil)
+			require.NoError(t, err)
+			require.Equal(t, "new-leader", string(result))
+			require.EqualValues(t, 1, oldWrites.Load())
+			require.EqualValues(t, 1, newWrites.Load())
+		})
+	}
+}
+
+func TestProposalObservationConcurrentDelta(t *testing.T) {
+	c := newProposalRouteTestCluster(t, nil)
+	view := controllermeta.SlotRuntimeView{SlotID: 1, LeaderID: 2, CurrentVoters: []uint64{2, 3}, ObservedConfigEpoch: 1, LastReportAt: time.Now()}
+	setProposalRouteTestObservation(c, view)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			c.agent.observationMu.Lock()
+			applyObservationDelta(&c.agent.observationState, observationDeltaResponse{
+				FullSync: true, LeaderID: 2, LeaderGeneration: 1,
+				RuntimeViews: []controllermeta.SlotRuntimeView{view},
+			})
+			c.agent.observationMu.Unlock()
+		}
+	}()
+	defer wg.Wait()
+	for i := 0; i < 1000; i++ {
+		require.EqualValues(t, 2, c.observedProposalLeader(1, []multiraft.NodeID{2, 3}))
+	}
+}
+
+func TestProposalObservationValidation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		change func(*controllermeta.SlotRuntimeView)
+		want   multiraft.NodeID
+	}{
+		{"fresh", func(*controllermeta.SlotRuntimeView) {}, 2},
+		{"expired", func(v *controllermeta.SlotRuntimeView) { v.LastReportAt = time.Now().Add(-time.Hour) }, 3},
+		{"future", func(v *controllermeta.SlotRuntimeView) { v.LastReportAt = time.Now().Add(time.Hour) }, 3},
+		{"no_timestamp", func(v *controllermeta.SlotRuntimeView) { v.LastReportAt = time.Time{} }, 3},
+		{"stale_epoch", func(v *controllermeta.SlotRuntimeView) { v.ObservedConfigEpoch = 0 }, 3},
+		{"removed_leader", func(v *controllermeta.SlotRuntimeView) { v.LeaderID = 4; v.CurrentVoters = []uint64{4} }, 3},
+		{"not_voter", func(v *controllermeta.SlotRuntimeView) { v.CurrentVoters = []uint64{3} }, 3},
+		{"unknown_leader", func(v *controllermeta.SlotRuntimeView) { v.LeaderID = 0 }, 3},
+		{"wrong_slot", func(v *controllermeta.SlotRuntimeView) { v.SlotID = 2 }, 3},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := newProposalRouteTestCluster(t, nil)
+			view := controllermeta.SlotRuntimeView{SlotID: 1, LeaderID: 2, CurrentVoters: []uint64{2, 3}, ObservedConfigEpoch: 1, LastReportAt: time.Now()}
+			test.change(&view)
+			setProposalRouteTestObservation(c, view)
+			c.setManagedSlotStatusTestHook(func(_ *Cluster, _ multiraft.NodeID, _ multiraft.SlotID) (managedSlotStatus, error, bool) {
+				return managedSlotStatus{LeaderID: 3, CurrentVoters: []multiraft.NodeID{2, 3}}, nil, true
+			})
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			leader, err := c.resolveProposalLeader(ctx, 1, false)
+			require.NoError(t, err)
+			require.Equal(t, test.want, leader)
+		})
+	}
+}
+
+func TestProposalDiscoveryDoesNotInventLeader(t *testing.T) {
+	for _, status := range []managedSlotStatus{
+		{},
+		{LeaderID: 4, CurrentVoters: []multiraft.NodeID{2, 3, 4}},
+		{LeaderID: 2, CurrentVoters: []multiraft.NodeID{3}},
+	} {
+		c := newProposalRouteTestCluster(t, nil)
+		c.setManagedSlotStatusTestHook(func(_ *Cluster, _ multiraft.NodeID, _ multiraft.SlotID) (managedSlotStatus, error, bool) {
+			return status, nil, true
+		})
+		_, err := c.resolveProposalLeader(context.Background(), 1, false)
+		require.ErrorIs(t, err, ErrNoLeader)
+	}
+}
+
+func TestProposalDiscoveryCancellationAndBudget(t *testing.T) {
+	c := newProposalRouteTestCluster(t, nil)
+	c.cfg.Timeouts.ForwardRetryBudget = 60 * time.Millisecond
+	var calls atomic.Int32
+	c.setManagedSlotStatusTestHook(func(_ *Cluster, _ multiraft.NodeID, _ multiraft.SlotID) (managedSlotStatus, error, bool) {
+		calls.Add(1)
+		return managedSlotStatus{}, ErrSlotNotFound, true
+	})
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, c.ProposeWithHashSlot(canceled, 1, 2, nil), context.Canceled)
+	require.Zero(t, calls.Load())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	start := time.Now()
+	err := c.ProposeWithHashSlot(ctx, 1, 2, nil)
+	require.Error(t, err)
+	require.Less(t, time.Since(start), 500*time.Millisecond, "must not use the caller's 5s as the routing budget")
+	require.NoError(t, ctx.Err())
+	require.Positive(t, calls.Load())
+}
+
+func TestProposalDiscoverySkipsSlowPeer(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	c := newProposalRouteTestCluster(t, map[multiraft.NodeID]proposalRouteTestHandler{
+		2: func(context.Context, uint8, []byte) ([]byte, error) {
+			<-release
+			return proposalRouteTestStatus(2)
+		},
+		3: func(_ context.Context, service uint8, _ []byte) ([]byte, error) {
+			if service == rpcServiceManagedSlot {
+				return proposalRouteTestStatus(3)
+			}
+			return encodeForwardResp(errCodeOK, nil), nil
+		},
+	})
+	require.NoError(t, c.ProposeWithHashSlot(context.Background(), 1, 2, nil))
+}
+
+func TestProposalDoesNotRetryAmbiguousForwardTimeout(t *testing.T) {
+	var writes atomic.Int32
+	c := newProposalRouteTestCluster(t, map[multiraft.NodeID]proposalRouteTestHandler{
+		2: func(_ context.Context, service uint8, _ []byte) ([]byte, error) {
+			if service == rpcServiceManagedSlot {
+				return proposalRouteTestStatus(2)
+			}
+			writes.Add(1)
+			return encodeForwardResp(errCodeTimeout, nil), nil
+		},
+	})
+	require.ErrorIs(t, c.ProposeWithHashSlot(context.Background(), 1, 2, nil), transport.ErrTimeout)
+	require.EqualValues(t, 1, writes.Load())
+}

--- a/pkg/cluster/router.go
+++ b/pkg/cluster/router.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"errors"
 	"sync/atomic"
 
 	"github.com/WuKongIM/WuKongIM/pkg/slot/multiraft"
@@ -53,12 +54,17 @@ func (r *Router) HashSlotsOf(slotID multiraft.SlotID) []uint16 {
 	return table.HashSlotsOf(slotID)
 }
 
+// LeaderOf reads only the local runtime's leader observation. A non-replica
+// returns ErrSlotNotFound even when the slot exists elsewhere in the cluster.
 func (r *Router) LeaderOf(slotID multiraft.SlotID) (multiraft.NodeID, error) {
 	if r == nil || r.runtime == nil {
 		return 0, ErrNotStarted
 	}
 	status, err := r.runtime.Status(slotID)
 	if err != nil {
+		if errors.Is(err, multiraft.ErrSlotNotFound) {
+			return 0, ErrSlotNotFound
+		}
 		return 0, err
 	}
 	if status.LeaderID == 0 {


### PR DESCRIPTION
## 问题

在 5 节点、每槽 3 副本的拓扑中，`/user/token` 请求落到 UID 槽的非副本节点时：权威 `GetUser` 可以成功，但 `UpsertDevice` 经通用提案入口调用本地 `Router.LeaderOf`，直接返回 `multiraft: slot not found`，无法走到远端转发。新账号的 `CreateUser` 同样受影响。

此外，Router 透出的 `multiraft.ErrSlotNotFound` 与上层检查的 `cluster.ErrSlotNotFound` 不是同一个错误，导致“只扫描本机 leader 槽”的 migration task scan 不能正确跳过非本地槽。

## 修复范围

- 通用 `ProposeWithHashSlot[Result]` 分离全局写入寻址与本地 runtime 检查：本地观测 → 现有 observation cache 中有效的 leader hint → 按全局 assignment 向副本执行已有 managed-slot status RPC，确认实际 leader 后转发。
- 缓存 hint 校验 slot、当前 peers/voters、assignment epoch 和时间；不把 `PreferredLeader` 或第一个副本当成实际 leader。最终写入仍由目标 Raft runtime 校验。
- `NotLeader` / 转发 `NoSlot` 后绕过旧 hint、重新探测；无 leader 可在预算内重试。探测按 peer 分配剩余预算，即使调用者 deadline 更长，重路由也受 `ForwardRetryBudget` 限制。网络/提交超时不自动重放。
- 保留 `LeaderOf`、`ProposeLocalWithHashSlot` 的 local-only 语义；统一缺少本机槽的错误为 `cluster.ErrSlotNotFound`。
- 不修改存储格式、RPC 格式或部署配置，不升级底座，不修改投递/未读业务算法。

参考官方当前 main 的全局路由思路（核查快照 `5459cfa73c43f5e3d9e5212d1a9121b6f2a6d659`）：

- [全局槽 leader 查询](https://github.com/WuKongIM/WuKongIM/blob/5459cfa73c43f5e3d9e5212d1a9121b6f2a6d659/pkg/cluster/node_slot_proxy_port.go)
- [非本地槽的实际 leader 观测](https://github.com/WuKongIM/WuKongIM/blob/5459cfa73c43f5e3d9e5212d1a9121b6f2a6d659/pkg/cluster/default_slot_leaders.go)
- [提案路由与转发](https://github.com/WuKongIM/WuKongIM/blob/5459cfa73c43f5e3d9e5212d1a9121b6f2a6d659/pkg/cluster/propose/service.go)

这是适配当前 fork 架构的定向实现，不是整体移植官方新架构，也不是升级到 v2.2.5。

## 验证

新增真实组件集成测试：5 个节点、3 个 controller voters、每槽 3 副本、10 个物理槽 / 64 个 hash slots、全部使用临时新数据库。经 HTTP handler → user usecase → proxy → TCP RPC / Raft 验证：

- 副本节点注册后，同账号在全部 5 个入口更新 token，并逐一从 5 节点权威读回。
- 每个入口注册一个映射到同槽的新账号，包含两个确实没有该槽本地 runtime 的入口。
- 本地提案仍拒绝非副本；5 个节点的 local-leader migration scan 均不因非本地槽失败。
- 实际转移 Raft leader 后，从两个非副本再次更新并从所有节点读回。

结果：

- 未修复 main `613fc2b2` 注入同一入口测试：复现 HTTP 400 `multiraft: slot not found`。
- 修复后包含 leader 转移的集成测试连续 3 次通过；每次 7 次 token 更新、35 次权威读回、5 次新账号注册、5 次本地扫描。
- `go test ./pkg/cluster ./pkg/slot/proxy ./internal/access/api ./internal/usecase/user ./internal` 通过。
- 新增路由定向单元测试 `-count=3` 通过；缓存与 observation delta 并发读写等非网络路由测试 `-race -count=3` 通过。
- 相关包 `go vet` 和 `go build ./cmd/wukongim` 通过。
- 独立工作树中将本提交应用到 PR #35 的 `ad02885d`：同一 5 节点入口集成测试通过，conversation / api / user 单元测试通过。

测试使用 `GOWORK=off GOMAXPROCS=2 GOMEMLIMIT=768MiB`，Go 命令附加 `-buildvcs=false -p 1`；真实集成测试通过 `-tags=integration -run '^TestTokenOnNonReplicaNodes$'` 单独运行。

## 未解决的独立问题 / 限制

网络路径的 `-race` **没有通过**：检测到原有 `pkg/transport/server.go:149/151` 对连接指针 `mc` 的发布竞争。已在未修改的 main 上用既有 `TestForwardToLeader_RoundTrip -race -count=20` 复现相同栈；该文件与 main 完全相同。本 PR 只在 `CODE_QUALITY.md` 记录，不夹带 transport 修复。

本 PR 直接基于 `main`，不包含 #35 / #37 / #38 的改动，也不替代 #35 的未读修复或 #38 的 delivery tag 修复。未重建现行业务集群，未声称完成完整 Octo 第二轮消息实验。
