### PR TITLE
fix: read conversation boundaries from channel leaders

### DIFF
--- a/docs/conversation-boundary-reads.md
+++ b/docs/conversation-boundary-reads.md
@@ -1,0 +1,55 @@
+# Conversation boundary reads on the v2.2.5 branch
+
+`clearUnread`, `setUnread`, and `delete` update conversations at the UID slot
+leader. Their message boundary is read separately from the channel leader.
+
+The metadata read captures a slot committed index and waits, within the request
+budget, until that fixed index has been applied. Later unrelated writes do not
+invalidate the read. Leadership changes still fail the read, and the caller
+and serving node recheck the channel configuration around the boundary read.
+
+For an active channel, the returned sequence is bounded by the committed index
+in the post-read Raft snapshot. A message appended to disk but still waiting for
+replication acknowledgements cannot advance the conversation boundary beyond
+that index. A commit completed during the read may be included.
+
+## Legacy recovery limitation
+
+The committed-index bound is only as reliable as the old runtime's recovered
+state. This branch initializes a channel's applied index from its durable message
+tail, and initializes the runtime committed index from that applied index.
+Although wkdb exposes a persistent channel applied-index key, the channel apply
+pipeline does not maintain it. Existing records cannot be assumed to contain a
+trustworthy independently persisted commit marker.
+
+Consequently, a dormant-channel read can return a crash-residue uncommitted
+suffix. Creating a runtime does not by itself resolve this: a freshly recovered
+runtime also initially regards that durable suffix as committed. Only subsequent
+replication/election reconciliation can establish the actual history. The active
+read bound prevents new in-flight suffixes from being returned, but does not
+repair this inherited recovery ambiguity. Resolving it requires commit-marker
+maintenance and an explicit migration/recovery policy for existing data.
+
+Dormant channels remain readable without being created or woken. This preserves
+the v2.2.5 behavior and the above residual risk; it is not a claim of the stronger
+committed-history guarantee provided by the refactored main branch. Missing
+metadata returns an empty boundary without creating a channel. Dormant channels
+with migration in progress are rejected.
+
+These local role/configuration checks are not a quorum ReadIndex or a leader
+lease. They do not guarantee linearizability across network partitions.
+
+## Rolling upgrades and errors
+
+The configuration and boundary RPCs use version 2 paths and responses. Version 1
+conversation-read peers, including the earlier experimental implementation that
+returned unbounded tails, are rejected. Existing unrelated RPCs are unchanged.
+An upgraded caller does not fall back to the older boundary protocol. The full
+fix requires upgrading participating nodes; requests served by old UID owners
+retain the old behavior until those nodes are upgraded.
+
+Each operation has one request budget and at most one route-refresh retry.
+Unresolved readiness, transport, or ownership failures return HTTP 503 with
+`{"msg":"retry required","status":503}`. Internal errors retain the channel,
+attempt and available peer/slot details for diagnosis; remote serving failures
+are also logged at debug level. Internal error text is not returned to API users.

--- a/internal/api/conversation.go
+++ b/internal/api/conversation.go
@@ -136,10 +136,10 @@ func (s *conversation) clearConversationUnread(c *wkhttp.Context) {
 	}
 
 	// 获取此频道最新的消息
-	lastMsgSeq, err := s.getChannelLastMsgSeq(fakeChannelId, req.ChannelType)
+	lastMsgSeq, err := s.getChannelLastMsgSeq(c.Request.Context(), fakeChannelId, req.ChannelType)
 	if err != nil {
 		s.Error("Failed to query last message", zap.Error(err))
-		c.ResponseError(err)
+		respondConversationReadRetry(c)
 		return
 	}
 
@@ -184,6 +184,10 @@ func (s *conversation) setConversationUnread(c *wkhttp.Context) {
 		c.ResponseError(errors.New("channel_id or channel_type cannot be empty"))
 		return
 	}
+	if req.Unread < 0 {
+		c.ResponseError(errors.New("unread cannot be negative"))
+		return
+	}
 
 	if options.G.ClusterOn() {
 		leaderInfo, err := service.Cluster.SlotLeaderOfChannel(req.UID, wkproto.ChannelTypePerson) // 获取频道的领导节点
@@ -206,10 +210,14 @@ func (s *conversation) setConversationUnread(c *wkhttp.Context) {
 
 	}
 	// 获取此频道最新的消息
-	lastMsgSeq, err := s.getChannelLastMsgSeq(fakeChannelId, req.ChannelType)
+	lastMsgSeq, err := s.getChannelLastMsgSeq(c.Request.Context(), fakeChannelId, req.ChannelType)
 	if err != nil {
 		s.Error("Failed to query last message", zap.Error(err))
-		c.ResponseError(err)
+		respondConversationReadRetry(c)
+		return
+	}
+	if lastMsgSeq == 0 {
+		c.ResponseOK()
 		return
 	}
 
@@ -298,10 +306,10 @@ func (s *conversation) deleteConversation(c *wkhttp.Context) {
 	}
 
 	// 获取频道最后一条消息序号
-	lastMsgSeq, err := s.getChannelLastMsgSeq(fakeChannelId, req.ChannelType)
+	lastMsgSeq, err := s.getChannelLastMsgSeq(c.Request.Context(), fakeChannelId, req.ChannelType)
 	if err != nil {
 		s.Error("获取频道最后一条消息序号失败！", zap.Error(err))
-		c.ResponseError(err)
+		respondConversationReadRetry(c)
 		return
 	}
 
@@ -695,12 +703,6 @@ func (s *conversation) conversationChannels(c *wkhttp.Context) {
 		})
 	}
 	c.JSON(http.StatusOK, channels)
-}
-
-// getChannelLastMsgSeqWithCache 使用缓存获取频道最后消息序号
-func (s *conversation) getChannelLastMsgSeq(channelId string, channelType uint8) (uint64, error) {
-
-	return service.Store.GetLastMsgSeq(channelId, channelType)
 }
 
 // syncConversationByChannels 通过频道集合同步会话数据

--- a/internal/api/conversation_latest.go
+++ b/internal/api/conversation_latest.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/internal/options"
+	"github.com/WuKongIM/WuKongIM/internal/service"
+	"github.com/WuKongIM/WuKongIM/pkg/wkhttp"
+)
+
+func (s *conversation) getChannelLastMsgSeq(ctx context.Context, channelID string, channelType uint8) (uint64, error) {
+	timeout := options.G.Cluster.ReqTimeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return service.Cluster.GetChannelLastMessageSeq(ctx, channelID, channelType)
+}
+
+func respondConversationReadRetry(c *wkhttp.Context) {
+	c.JSON(http.StatusServiceUnavailable, map[string]interface{}{"msg": "retry required", "status": http.StatusServiceUnavailable})
+}

--- a/internal/api/conversation_test.go
+++ b/internal/api/conversation_test.go
@@ -1,1 +1,216 @@
 package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/internal/options"
+	"github.com/WuKongIM/WuKongIM/internal/service"
+	"github.com/WuKongIM/WuKongIM/pkg/cluster/icluster"
+	clustertypes "github.com/WuKongIM/WuKongIM/pkg/cluster/node/types"
+	"github.com/WuKongIM/WuKongIM/pkg/cluster/store"
+	rafttypes "github.com/WuKongIM/WuKongIM/pkg/raft/types"
+	"github.com/WuKongIM/WuKongIM/pkg/wkdb"
+	"github.com/WuKongIM/WuKongIM/pkg/wkhttp"
+)
+
+// Separate the UID owner from the channel message owner. The real handlers and
+// Store command codecs below must never use the UID owner's local message tail.
+type conversationBoundaryCluster struct {
+	icluster.ICluster
+	seq   uint64
+	err   error
+	delay bool
+}
+
+func (c *conversationBoundaryCluster) SlotLeaderOfChannel(string, uint8) (*clustertypes.Node, error) {
+	return &clustertypes.Node{Id: 1001}, nil
+}
+func (c *conversationBoundaryCluster) GetChannelLastMessageSeq(ctx context.Context, id string, typ uint8) (uint64, error) {
+	expected := "bob"
+	if typ == 1 {
+		expected = options.GetFakeChannelIDWith("alice", "bob")
+	}
+	if id != expected {
+		return 0, fmt.Errorf("unexpected channel %q", id)
+	}
+	if c.delay {
+		<-ctx.Done()
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	return c.seq, c.err
+}
+
+type conversationBoundaryDB struct {
+	wkdb.DB
+	localSeq uint64
+	readTo   uint64
+	reads    int
+}
+
+func (d *conversationBoundaryDB) GetChannelLastMessageSeq(string, uint8) (uint64, uint64, error) {
+	d.reads++
+	return d.localSeq, 0, nil
+}
+func (d *conversationBoundaryDB) GetConversation(uid, channel string, typ uint8) (wkdb.Conversation, error) {
+	return wkdb.Conversation{Id: 1, Uid: uid, ChannelId: channel, ChannelType: typ, Type: wkdb.ConversationTypeChat, ReadToMsgSeq: d.readTo}, nil
+}
+
+type conversationBoundarySlot struct {
+	icluster.Slot
+	boundaries []uint64
+}
+
+func (s *conversationBoundarySlot) GetSlotId(string) uint32 { return 7 }
+func (s *conversationBoundarySlot) ProposeUntilApplied(_ uint32, data []byte) (*rafttypes.ProposeResp, error) {
+	cmd := &store.CMD{}
+	if err := cmd.Unmarshal(data); err != nil {
+		return nil, err
+	}
+	switch cmd.CmdType {
+	case store.CMDAddOrUpdateUserConversations:
+		_, conversations, err := cmd.DecodeCMDAddOrUpdateUserConversations()
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range conversations {
+			s.boundaries = append(s.boundaries, c.ReadToMsgSeq)
+		}
+	case store.CMDUpdateConversationDeletedAtMsgSeq:
+		_, _, _, seq, err := cmd.DecodeCMDUpdateConversationDeletedAtMsgSeq()
+		if err != nil {
+			return nil, err
+		}
+		s.boundaries = append(s.boundaries, seq)
+	default:
+		return nil, fmt.Errorf("unexpected command %s", cmd.CmdType)
+	}
+	return &rafttypes.ProposeResp{}, nil
+}
+
+func conversationBoundaryRequest(t *testing.T, path string, typ uint8, unread int, localSeq, remoteSeq uint64, remoteStatus int, readTo ...uint64) (int, []uint64, int) {
+	t.Helper()
+	oldOptions, oldCluster, oldStore := options.G, service.Cluster, service.Store
+	defer func() { options.G, service.Cluster, service.Store = oldOptions, oldCluster, oldStore }()
+	options.G = options.New()
+	options.G.Cluster.NodeId = 1001
+	cluster := &conversationBoundaryCluster{seq: remoteSeq}
+	if remoteStatus == 503 {
+		cluster.err = errors.New("private storage path must not leak")
+	}
+	if remoteStatus == 504 {
+		cluster.delay = true
+	}
+	options.G.Cluster.ReqTimeout = 20 * time.Millisecond
+	service.Cluster = cluster
+	db := &conversationBoundaryDB{localSeq: localSeq}
+	if len(readTo) > 0 {
+		db.readTo = readTo[0]
+	}
+	slot := &conversationBoundarySlot{}
+	service.Store = store.New(store.NewOptions(store.WithDB(db), store.WithSlot(slot)))
+	router := wkhttp.New()
+	newConversation(nil).route(router)
+	body := fmt.Sprintf(`{"uid":"alice","channel_id":"bob","channel_type":%d,"unread":%d}`, typ, unread)
+	req := httptest.NewRequest(http.MethodPost, "/conversations/"+path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if remoteStatus == 499 {
+		ctx, cancel := context.WithCancel(req.Context())
+		cancel()
+		req = req.WithContext(ctx)
+	}
+	response := httptest.NewRecorder()
+	router.GetGinRoute().ServeHTTP(response, req)
+	t.Logf("path=%s type=%d local_seq=%d remote_seq=%d remote_status=%d http=%d writes=%v local_reads=%d", path, typ, localSeq, remoteSeq, remoteStatus, response.Code, slot.boundaries, db.reads)
+	if response.Code == 503 && strings.TrimSpace(response.Body.String()) != `{"msg":"retry required","status":503}` {
+		t.Errorf("unstable error response: %s", response.Body.String())
+	}
+	return response.Code, slot.boundaries, db.reads
+}
+
+func TestConversationBoundary(t *testing.T) {
+	for _, path := range []string{"clearUnread", "setUnread", "delete"} {
+		for _, typ := range []uint8{1, 2} {
+			for _, localSeq := range []uint64{0, 7} {
+				t.Run(fmt.Sprintf("%s/type%d/local%d", path, typ, localSeq), func(t *testing.T) {
+					status, writes, reads := conversationBoundaryRequest(t, path, typ, 0, localSeq, 42, 200)
+					if status != 200 || len(writes) != 1 || writes[0] != 42 || reads != 0 {
+						t.Errorf("must use channel leader boundary 42; got HTTP=%d boundaries=%v local_reads=%d", status, writes, reads)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestConversationRemoteFailure(t *testing.T) {
+	for _, path := range []string{"clearUnread", "setUnread", "delete"} {
+		t.Run(path, func(t *testing.T) {
+			status, writes, reads := conversationBoundaryRequest(t, path, 1, 0, 7, 42, 503)
+			if status != 503 || len(writes) != 0 || reads != 0 {
+				t.Errorf("remote failure must not commit a local fallback; HTTP=%d boundaries=%v local_reads=%d", status, writes, reads)
+			}
+		})
+	}
+}
+
+func TestConversationInvalidArithmetic(t *testing.T) {
+	t.Run("zero_sequence_with_unread", func(t *testing.T) {
+		status, writes, _ := conversationBoundaryRequest(t, "setUnread", 2, 5, 0, 0, 200)
+		if status != 200 || len(writes) != 0 {
+			t.Errorf("zero sequence must not underflow; HTTP=%d boundaries=%v", status, writes)
+		}
+	})
+	t.Run("negative_unread", func(t *testing.T) {
+		status, writes, _ := conversationBoundaryRequest(t, "setUnread", 2, -1, 7, 42, 200)
+		if status != 400 || len(writes) != 0 {
+			t.Errorf("negative unread must be rejected; HTTP=%d boundaries=%v", status, writes)
+		}
+	})
+}
+
+func TestConversationBoundaryTimeout(t *testing.T) {
+	for _, path := range []string{"clearUnread", "setUnread", "delete"} {
+		t.Run(path, func(t *testing.T) {
+			status, writes, reads := conversationBoundaryRequest(t, path, 1, 0, 7, 42, 504)
+			if status != 503 || len(writes) != 0 || reads != 0 {
+				t.Fatalf("status=%d writes=%v reads=%d", status, writes, reads)
+			}
+		})
+	}
+}
+func TestConversationSetUnreadBoundary(t *testing.T) {
+	status, writes, reads := conversationBoundaryRequest(t, "setUnread", 2, 3, 7, 42, 200)
+	if status != 200 || len(writes) != 1 || writes[0] != 39 || reads != 0 {
+		t.Fatalf("status=%d writes=%v reads=%d", status, writes, reads)
+	}
+}
+
+func TestConversationBoundaryCanceled(t *testing.T) {
+	for _, path := range []string{"clearUnread", "setUnread", "delete"} {
+		t.Run(path, func(t *testing.T) {
+			status, writes, reads := conversationBoundaryRequest(t, path, 1, 0, 7, 42, 499)
+			if status != 503 || len(writes) != 0 || reads != 0 {
+				t.Fatalf("status=%d writes=%v reads=%d", status, writes, reads)
+			}
+		})
+	}
+}
+func TestConversationUnreadDoesNotRegress(t *testing.T) {
+	for _, path := range []string{"clearUnread", "setUnread"} {
+		t.Run(path, func(t *testing.T) {
+			status, writes, reads := conversationBoundaryRequest(t, path, 2, 0, 7, 42, 200, 100)
+			if status != 200 || len(writes) != 0 || reads != 0 {
+				t.Fatalf("status=%d writes=%v reads=%d", status, writes, reads)
+			}
+		})
+	}
+}

--- a/pkg/cluster/channel/server.go
+++ b/pkg/cluster/channel/server.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"context"
 	"sync"
 
 	"github.com/WuKongIM/WuKongIM/pkg/fasthash"
@@ -12,6 +13,12 @@ import (
 	"github.com/WuKongIM/WuKongIM/pkg/wkutil"
 	"go.uber.org/zap"
 )
+
+// ReadLeaderState observes an existing channel without waking or creating it.
+func (s *Server) ReadLeaderState(ctx context.Context, channelID string, channelType uint8) (raftgroup.ReadState, error) {
+	key := wkutil.ChannelToKey(channelID, channelType)
+	return s.getRaftGroup(key).ReadLeaderState(ctx, key)
+}
 
 type Server struct {
 	raftGroups []*raftgroup.RaftGroup

--- a/pkg/cluster/cluster/conversation_config_read.go
+++ b/pkg/cluster/cluster/conversation_config_read.go
@@ -1,0 +1,68 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/raftgroup"
+	"github.com/WuKongIM/WuKongIM/pkg/wkdb"
+)
+
+type conversationConfigReader struct {
+	nodeID uint64
+	leader func() uint64
+	state  func(context.Context) (raftgroup.ReadState, error)
+	load   func() (wkdb.ChannelClusterConfig, error)
+}
+
+func sameConversationLeader(before, after raftgroup.ReadState) bool {
+	return after.Exists && after.Ready && before.LeaderID == after.LeaderID &&
+		before.Term == after.Term && before.ConfigVersion == after.ConfigVersion
+}
+
+func (r conversationConfigReader) read(ctx context.Context) (wkdb.ChannelClusterConfig, error) {
+	before, err := r.state(ctx)
+	if err != nil {
+		return wkdb.EmptyChannelClusterConfig, err
+	}
+	if !before.Exists || !before.Ready || before.LeaderID != r.nodeID || r.leader() != r.nodeID {
+		return wkdb.EmptyChannelClusterConfig, fmt.Errorf("%w: metadata slot is not a ready local leader", ErrConversationReadRetry)
+	}
+	// Fix the target once. Unrelated proposals can continue to commit while we
+	// wait; chasing their growing committed index would require an idle slot.
+	current := before
+	if current.AppliedIndex < before.CommittedIndex {
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		for current.AppliedIndex < before.CommittedIndex {
+			select {
+			case <-ctx.Done():
+				return wkdb.EmptyChannelClusterConfig, ctx.Err()
+			case <-ticker.C:
+			}
+			current, err = r.state(ctx)
+			if err != nil {
+				return wkdb.EmptyChannelClusterConfig, err
+			}
+			if !sameConversationLeader(before, current) || r.leader() != r.nodeID {
+				return wkdb.EmptyChannelClusterConfig, fmt.Errorf("%w: metadata leadership changed while waiting for apply", ErrConversationReadRetry)
+			}
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return wkdb.EmptyChannelClusterConfig, err
+	}
+	cfg, readErr := r.load()
+	after, err := r.state(ctx)
+	if err != nil {
+		return wkdb.EmptyChannelClusterConfig, err
+	}
+	if !sameConversationLeader(before, after) || r.leader() != r.nodeID || after.AppliedIndex < before.CommittedIndex {
+		return wkdb.EmptyChannelClusterConfig, fmt.Errorf("%w: metadata leadership or applied barrier changed during read", ErrConversationReadRetry)
+	}
+	if err := ctx.Err(); err != nil {
+		return wkdb.EmptyChannelClusterConfig, err
+	}
+	return cfg, readErr
+}

--- a/pkg/cluster/cluster/conversation_config_read_test.go
+++ b/pkg/cluster/cluster/conversation_config_read_test.go
@@ -1,0 +1,124 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/raftgroup"
+	"github.com/WuKongIM/WuKongIM/pkg/wkdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConversationConfigFixedApplyBarrier(t *testing.T) {
+	states := []raftgroup.ReadState{
+		{Exists: true, Ready: true, LeaderID: 1, Term: 3, CommittedIndex: 10, AppliedIndex: 7},
+		{Exists: true, Ready: true, LeaderID: 1, Term: 3, CommittedIndex: 11, AppliedIndex: 10},
+		{Exists: true, Ready: true, LeaderID: 1, Term: 3, CommittedIndex: 12, AppliedIndex: 11},
+	}
+	snapshots, loads := 0, 0
+	r := conversationConfigReader{
+		nodeID: 1, leader: func() uint64 { return 1 },
+		state: func(context.Context) (raftgroup.ReadState, error) {
+			require.Less(t, snapshots, len(states), "must not chase later commits")
+			s := states[snapshots]
+			snapshots++
+			return s, nil
+		},
+		load: func() (wkdb.ChannelClusterConfig, error) {
+			require.Equal(t, 2, snapshots, "DB read must wait for the captured commit")
+			loads++
+			return boundaryConfig(), nil
+		},
+	}
+	cfg, err := r.read(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, boundaryConfig(), cfg)
+	require.Equal(t, 1, loads)
+	require.Equal(t, 3, snapshots)
+}
+
+func TestConversationConfigLeadershipFence(t *testing.T) {
+	for _, phase := range []string{"waiting", "after DB"} {
+		for _, change := range []string{"leader", "term", "version", "removed", "draining", "route"} {
+			t.Run(phase+"/"+change, func(t *testing.T) {
+				base := raftgroup.ReadState{Exists: true, Ready: true, LeaderID: 1, Term: 3, ConfigVersion: 4, CommittedIndex: 10, AppliedIndex: 10}
+				calls, loads, route := 0, 0, uint64(1)
+				r := conversationConfigReader{nodeID: 1, leader: func() uint64 { return route }}
+				r.state = func(context.Context) (raftgroup.ReadState, error) {
+					calls++
+					s := base
+					if calls == 1 && phase == "waiting" {
+						s.AppliedIndex = 9
+					}
+					if calls > 1 {
+						switch change {
+						case "leader":
+							s.LeaderID = 2
+						case "term":
+							s.Term++
+						case "version":
+							s.ConfigVersion++
+						case "removed":
+							s.Exists = false
+						case "draining":
+							s.Ready = false
+						case "route":
+							route = 2
+						}
+					}
+					return s, nil
+				}
+				r.load = func() (wkdb.ChannelClusterConfig, error) { loads++; return boundaryConfig(), nil }
+				_, err := r.read(context.Background())
+				require.ErrorIs(t, err, ErrConversationReadRetry)
+				if phase == "waiting" {
+					require.Zero(t, loads)
+				} else {
+					require.Equal(t, 1, loads)
+				}
+			})
+		}
+	}
+}
+
+func TestConversationConfigApplyCancellation(t *testing.T) {
+	for _, timeout := range []bool{false, true} {
+		t.Run(map[bool]string{false: "cancel", true: "deadline"}[timeout], func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Millisecond)
+			defer cancel()
+			r := conversationConfigReader{nodeID: 1, leader: func() uint64 { return 1 }}
+			r.state = func(context.Context) (raftgroup.ReadState, error) {
+				if !timeout {
+					cancel()
+				}
+				return raftgroup.ReadState{Exists: true, Ready: true, LeaderID: 1, Term: 1, CommittedIndex: 10}, nil
+			}
+			r.load = func() (wkdb.ChannelClusterConfig, error) {
+				t.Fatal("must not read before apply")
+				return wkdb.EmptyChannelClusterConfig, nil
+			}
+			_, err := r.read(ctx)
+			if timeout {
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+			} else {
+				require.ErrorIs(t, err, context.Canceled)
+			}
+		})
+	}
+}
+
+func TestConversationConfigStorageErrors(t *testing.T) {
+	for _, readErr := range []error{wkdb.ErrNotFound, errors.New("disk unavailable")} {
+		r := conversationConfigReader{
+			nodeID: 1, leader: func() uint64 { return 1 },
+			state: func(context.Context) (raftgroup.ReadState, error) {
+				return raftgroup.ReadState{Exists: true, Ready: true, LeaderID: 1, Term: 1}, nil
+			},
+			load: func() (wkdb.ChannelClusterConfig, error) { return wkdb.EmptyChannelClusterConfig, readErr },
+		}
+		_, err := r.read(context.Background())
+		require.ErrorIs(t, err, readErr)
+	}
+}

--- a/pkg/cluster/cluster/conversation_consistency_integration_test.go
+++ b/pkg/cluster/cluster/conversation_consistency_integration_test.go
@@ -1,0 +1,237 @@
+package cluster
+
+import (
+	"context"
+	"github.com/WuKongIM/WuKongIM/pkg/cluster/node/clusterconfig"
+	"github.com/WuKongIM/WuKongIM/pkg/cluster/store"
+	rafttypes "github.com/WuKongIM/WuKongIM/pkg/raft/types"
+	"github.com/WuKongIM/WuKongIM/pkg/trace"
+	"github.com/WuKongIM/WuKongIM/pkg/wkdb"
+	"github.com/WuKongIM/WuKongIM/pkg/wkutil"
+	wkproto "github.com/WuKongIM/WuKongIMGoProto"
+	"github.com/stretchr/testify/require"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newConversationConsistencyServer(t *testing.T, decorate func(*Server)) (*Server, context.Context) {
+	t.Helper()
+	previous := trace.GlobalTrace
+	trace.SetGlobalTrace(trace.New(context.Background(), trace.NewOptions()))
+	t.Cleanup(func() { trace.SetGlobalTrace(previous) })
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	address := listener.Addr().String()
+	require.NoError(t, listener.Close())
+	config := newTestOptions(t, 1, nil, clusterconfig.WithSlotCount(1), clusterconfig.WithSlotMaxReplicaCount(1))
+	s := New(NewOptions(WithAddr("tcp://"+address), WithConfigOptions(config), WithDataDir(t.TempDir()),
+		WithDBWKDbShardNum(1), WithDBSlotShardNum(1), WithDBWKDbMemTableSize(1<<20), WithDBSlotMemTableSize(1<<20)))
+	if decorate != nil {
+		decorate(s)
+	}
+	require.NoError(t, s.Start())
+	t.Cleanup(s.Stop)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, s.WaitAllSlotReady(ctx, 1))
+	return s, ctx
+}
+func consistencyConfig() wkdb.ChannelClusterConfig {
+	return wkdb.ChannelClusterConfig{ChannelId: "analysis-channel", ChannelType: 2, LeaderId: 1, Term: 1,
+		ConfVersion: 1, ReplicaMaxCount: 1, Replicas: []uint64{1}, Status: wkdb.ChannelClusterStatusNormal}
+}
+func consistencyMessage(seq uint32) wkdb.Message {
+	return wkdb.Message{Term: 1, RecvPacket: wkproto.RecvPacket{ChannelID: "analysis-channel", ChannelType: 2,
+		MessageID: int64(seq), MessageSeq: seq, Payload: []byte("diagnostic")}}
+}
+
+type delayedConversationDB struct {
+	wkdb.DB
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (d *delayedConversationDB) AddOrUpdateConversationsWithUser(uid string, c []wkdb.Conversation) error {
+	if uid == "analysis-blocked" {
+		d.once.Do(func() { close(d.entered) })
+		<-d.release
+	}
+	return d.DB.AddOrUpdateConversationsWithUser(uid, c)
+}
+func TestConversationSlotApplyLag(t *testing.T) {
+	var db *delayedConversationDB
+	s, ctx := newConversationConsistencyServer(t, func(s *Server) {
+		db = &delayedConversationDB{DB: s.db, entered: make(chan struct{}), release: make(chan struct{})}
+		s.store = store.New(store.NewOptions(store.WithNodeId(1), store.WithSlot(s.slotServer), store.WithChannel(s.channelServer), store.WithDB(db)))
+	})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(db.release) }) }
+	t.Cleanup(release)
+	cfg := consistencyConfig()
+	require.NoError(t, s.db.SaveChannelClusterConfig(cfg))
+	require.NoError(t, s.db.AppendMessages(cfg.ChannelId, cfg.ChannelType, []wkdb.Message{consistencyMessage(42)}))
+	seq, err := s.GetChannelLastMessageSeq(ctx, cfg.ChannelId, cfg.ChannelType)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), seq)
+	done := make(chan error, 1)
+	go func() {
+		done <- s.store.AddOrUpdateUserConversations("analysis-blocked", []wkdb.Conversation{{Uid: "analysis-blocked", ChannelId: "unrelated", ChannelType: 2, Type: wkdb.ConversationTypeChat, ReadToMsgSeq: 1}})
+	}()
+	select {
+	case <-db.entered:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	state, err := s.slotServer.ReadLeaderState(ctx, 0)
+	require.NoError(t, err)
+	require.Less(t, state.AppliedIndex, state.CommittedIndex)
+	readCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	type readResult struct {
+		seq uint64
+		err error
+	}
+	result := make(chan readResult, 1)
+	go func() {
+		seq, err := s.GetChannelLastMessageSeq(readCtx, cfg.ChannelId, cfg.ChannelType)
+		result <- readResult{seq, err}
+	}()
+	select {
+	case r := <-result:
+		t.Fatalf("returned before apply despite available budget: %+v", r)
+	case <-time.After(20 * time.Millisecond):
+	}
+	release()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	select {
+	case r := <-result:
+		require.NoError(t, r.err)
+		require.Equal(t, uint64(42), r.seq)
+	case <-readCtx.Done():
+		t.Fatal(readCtx.Err())
+	}
+	require.Eventually(t, func() bool {
+		st, err := s.slotServer.ReadLeaderState(ctx, 0)
+		return err == nil && st.AppliedIndex >= state.CommittedIndex
+	}, time.Second, time.Millisecond)
+	seq, err = s.GetChannelLastMessageSeq(ctx, cfg.ChannelId, cfg.ChannelType)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), seq)
+	t.Logf("read waited for unrelated apply; sequence=%d", seq)
+}
+
+type conversationConfigHookDB struct {
+	wkdb.DB
+	mu   sync.Mutex
+	hook func()
+}
+
+func (d *conversationConfigHookDB) GetChannelClusterConfig(id string, typ uint8) (wkdb.ChannelClusterConfig, error) {
+	cfg, err := d.DB.GetChannelClusterConfig(id, typ)
+	d.mu.Lock()
+	hook := d.hook
+	d.hook = nil
+	d.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
+	return cfg, err
+}
+func TestConversationConcurrentSlotWrite(t *testing.T) {
+	var db *conversationConfigHookDB
+	s, ctx := newConversationConsistencyServer(t, func(s *Server) { db = &conversationConfigHookDB{DB: s.db}; s.db = db })
+	cfg := consistencyConfig()
+	require.NoError(t, s.db.SaveChannelClusterConfig(cfg))
+	before, err := s.slotServer.ReadLeaderState(ctx, 0)
+	require.NoError(t, err)
+	originalConfig, err := db.DB.GetChannelClusterConfig(cfg.ChannelId, cfg.ChannelType)
+	require.NoError(t, err)
+	db.mu.Lock()
+	db.hook = func() {
+		require.NoError(t, s.store.AddOrUpdateUserConversations("analysis-other", []wkdb.Conversation{{Uid: "analysis-other", ChannelId: "unrelated", ChannelType: 2, Type: wkdb.ConversationTypeChat, ReadToMsgSeq: 1}}))
+		require.Eventually(t, func() bool {
+			st, err := s.slotServer.ReadLeaderState(ctx, 0)
+			return err == nil && st.AppliedIndex > before.AppliedIndex
+		}, time.Second, time.Millisecond)
+	}
+	db.mu.Unlock()
+	_, err = s.loadConversationConfigLocal(ctx, cfg.ChannelId, cfg.ChannelType)
+	require.NoError(t, err)
+	after, stateErr := s.slotServer.ReadLeaderState(ctx, 0)
+	require.NoError(t, stateErr)
+	unchanged, loadErr := db.DB.GetChannelClusterConfig(cfg.ChannelId, cfg.ChannelType)
+	require.NoError(t, loadErr)
+	require.True(t, originalConfig.Equal(unchanged))
+	require.Equal(t, before.LeaderID, after.LeaderID)
+	require.Equal(t, before.Term, after.Term)
+	t.Logf("unrelated write: before committed/applied=%d/%d after=%d/%d sameLeader=%t sameTerm=%t sameChannelConfig=true readErr=%v", before.CommittedIndex, before.AppliedIndex, after.CommittedIndex, after.AppliedIndex, before.LeaderID == after.LeaderID, before.Term == after.Term, err)
+}
+func TestConversationUncommittedTail(t *testing.T) {
+	s, ctx := newConversationConsistencyServer(t, nil)
+	cfg := consistencyConfig()
+	cfg.ReplicaMaxCount = 3
+	cfg.Replicas = []uint64{1, 2, 3}
+	require.NoError(t, s.db.SaveChannelClusterConfig(cfg))
+	require.NoError(t, s.db.AppendMessages(cfg.ChannelId, cfg.ChannelType, []wkdb.Message{consistencyMessage(41)}))
+	require.NoError(t, s.channelServer.WakeLeaderIfNeed(cfg))
+	before, err := s.channelServer.ReadLeaderState(ctx, cfg.ChannelId, cfg.ChannelType)
+	require.NoError(t, err)
+	require.Equal(t, uint64(41), before.CommittedIndex)
+	msg := consistencyMessage(42)
+	data, err := msg.Marshal()
+	require.NoError(t, err)
+	// Run the actual Raft append/store pipeline, with no follower ACKs for index 42.
+	s.channelServer.AddEvent(wkutil.ChannelToKey(cfg.ChannelId, cfg.ChannelType), rafttypes.Event{Type: rafttypes.Propose, Logs: []rafttypes.Log{{Id: 42, Index: 42, Term: 1, Data: data}}})
+	require.Eventually(t, func() bool {
+		tail, _, err := s.db.GetChannelLastMessageSeq(cfg.ChannelId, cfg.ChannelType)
+		return err == nil && tail == 42
+	}, time.Second, time.Millisecond)
+	state, err := s.channelServer.ReadLeaderState(ctx, cfg.ChannelId, cfg.ChannelType)
+	require.NoError(t, err)
+	require.Equal(t, uint64(41), state.CommittedIndex)
+	seq, err := s.GetChannelLastMessageSeq(ctx, cfg.ChannelId, cfg.ChannelType)
+	require.NoError(t, err)
+	require.Equal(t, uint64(41), seq)
+	t.Logf("committed boundary: exists=%t ready=%t committed=%d applied=%d dbTail=42 returnedSeq=%d err=%v", state.Exists, state.Ready, state.CommittedIndex, state.AppliedIndex, seq, err)
+}
+
+func TestConversationReadDuringSlotWrites(t *testing.T) {
+	s, ctx := newConversationConsistencyServer(t, nil)
+	cfg := consistencyConfig()
+	require.NoError(t, s.db.SaveChannelClusterConfig(cfg))
+	require.NoError(t, s.db.AppendMessages(cfg.ChannelId, cfg.ChannelType, []wkdb.Message{consistencyMessage(42)}))
+	require.NoError(t, s.channelServer.WakeLeaderIfNeed(cfg))
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		for i := uint64(1); i <= 40; i++ {
+			err := s.store.AddOrUpdateUserConversations("busy-user", []wkdb.Conversation{{Uid: "busy-user", ChannelId: "other-channel", ChannelType: 2, Type: wkdb.ConversationTypeChat, ReadToMsgSeq: i}})
+			if err != nil {
+				done <- err
+				return
+			}
+		}
+		done <- nil
+	}()
+	<-started
+	for i := 0; i < 20; i++ {
+		seq, err := s.GetChannelLastMessageSeq(ctx, cfg.ChannelId, cfg.ChannelType)
+		require.NoError(t, err)
+		require.Equal(t, uint64(42), seq)
+	}
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+}

--- a/pkg/cluster/cluster/conversation_read.go
+++ b/pkg/cluster/cluster/conversation_read.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/WuKongIM/WuKongIM/pkg/raft/raftgroup"
@@ -11,13 +12,15 @@ import (
 	"github.com/WuKongIM/WuKongIM/pkg/wkserver"
 	"github.com/WuKongIM/WuKongIM/pkg/wkserver/proto"
 	"github.com/WuKongIM/WuKongIM/pkg/wkutil"
+	"go.uber.org/zap"
 )
 
 var ErrConversationReadRetry = errors.New("retry required")
 
 const (
-	conversationConfigPath   = "/rpc/channel/conversationConfig/v1"
-	conversationBoundaryPath = "/rpc/channel/conversationBoundary/v1"
+	conversationReadVersion  = 2
+	conversationConfigPath   = "/rpc/channel/conversationConfig/v2"
+	conversationBoundaryPath = "/rpc/channel/conversationBoundary/v2"
 )
 
 type conversationReadRequest struct {
@@ -64,6 +67,7 @@ func (s *Server) GetChannelLastMessageSeq(ctx context.Context, channelID string,
 
 func (r conversationReader) latest(ctx context.Context, id string, typ uint8) (uint64, error) {
 	seenConfig := false
+	var lastErr error
 	for attempt := 0; attempt < 2; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return 0, err
@@ -80,11 +84,12 @@ func (r conversationReader) latest(ctx context.Context, id string, typ uint8) (u
 		if err == nil {
 			return seq, ctx.Err()
 		}
+		lastErr = fmt.Errorf("attempt %d: %w", attempt+1, err)
 	}
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	return 0, ErrConversationReadRetry
+	return 0, fmt.Errorf("%w: channel %q type %d: %v", ErrConversationReadRetry, id, typ, lastErr)
 }
 
 func (r conversationReader) attempt(ctx context.Context, id string, typ uint8, allowMissing bool) (uint64, bool, error) {
@@ -107,7 +112,7 @@ func (r conversationReader) attempt(ctx context.Context, id string, typ uint8, a
 		resp, err = r.remote(ctx, cfg.LeaderId, conversationBoundaryPath,
 			conversationReadRequest{ChannelID: id, ChannelType: typ, Expected: cfg})
 		if err == nil {
-			if resp.Version != 1 || resp.Sequence == nil || resp.Config == nil || !cfg.Equal(*resp.Config) {
+			if resp.Version != conversationReadVersion || resp.Sequence == nil || resp.Config == nil || !cfg.Equal(*resp.Config) {
 				err = ErrConversationReadRetry
 			} else {
 				seq = *resp.Sequence
@@ -115,7 +120,7 @@ func (r conversationReader) attempt(ctx context.Context, id string, typ uint8, a
 		}
 	}
 	if err != nil {
-		return 0, true, err
+		return 0, true, fmt.Errorf("channel leader %d: %w", cfg.LeaderId, err)
 	}
 	after, err := r.load(ctx, id, typ)
 	if err != nil {
@@ -171,6 +176,12 @@ func (r conversationReader) readLocal(ctx context.Context, expected wkdb.Channel
 	if !cfg.Equal(latest) {
 		return 0, ErrConversationReadRetry
 	}
+	if after.Exists {
+		// A stored suffix may still be waiting for quorum ACKs. Never persist it
+		// as a conversation cursor. Use the post-read snapshot so a first message
+		// committed during this read is not discarded by the older snapshot.
+		seq = min(seq, after.CommittedIndex)
+	}
 	return seq, ctx.Err()
 }
 
@@ -179,6 +190,9 @@ func conversationStateReady(state raftgroup.ReadState, cfg wkdb.ChannelClusterCo
 		// Idle channels are automatically destroyed in this architecture. Reading
 		// their designated owner's durable tail must not wake them. A dormant
 		// channel in transfer cannot establish that it finished draining.
+		// Legacy storage does not persist a trustworthy committed bound across
+		// eviction/restart: dormant tails can include crash residue. See the
+		// compatibility note in docs/conversation-boundary-reads.md.
 		return cfg.MigrateFrom == 0 && cfg.MigrateTo == 0
 	}
 	return state.Ready && state.LeaderID == cfg.LeaderId && state.Term == cfg.Term && state.ConfigVersion == cfg.ConfVersion
@@ -207,14 +221,17 @@ func (s *Server) requestConversationRead(ctx context.Context, nodeID uint64, pat
 	if err != nil {
 		return conversationReadResponse{}, err
 	}
-	if resp == nil || resp.Status != proto.StatusOK {
-		return conversationReadResponse{}, ErrConversationReadRetry
+	if resp == nil {
+		return conversationReadResponse{}, fmt.Errorf("%w: peer %d path %s returned no response", ErrConversationReadRetry, nodeID, path)
+	}
+	if resp.Status != proto.StatusOK {
+		return conversationReadResponse{}, fmt.Errorf("%w: peer %d path %s status %v", ErrConversationReadRetry, nodeID, path, resp.Status)
 	}
 	var result conversationReadResponse
 	if err := json.Unmarshal(resp.Body, &result); err != nil {
 		return result, err
 	}
-	if result.Version != 1 {
+	if result.Version != conversationReadVersion {
 		return result, ErrConversationReadRetry
 	}
 	return result, ctx.Err()
@@ -249,26 +266,19 @@ func (s *Server) loadConversationConfig(ctx context.Context, id string, typ uint
 
 func (s *Server) loadConversationConfigLocal(ctx context.Context, id string, typ uint8) (wkdb.ChannelClusterConfig, error) {
 	slotID := s.getSlotId(id)
-	before, err := s.slotServer.ReadLeaderState(ctx, slotID)
+	reader := conversationConfigReader{
+		nodeID: s.opts.ConfigOptions.NodeId,
+		leader: func() uint64 { return s.cfgServer.SlotLeaderId(slotID) },
+		state: func(ctx context.Context) (raftgroup.ReadState, error) {
+			return s.slotServer.ReadLeaderState(ctx, slotID)
+		},
+		load: func() (wkdb.ChannelClusterConfig, error) { return s.db.GetChannelClusterConfig(id, typ) },
+	}
+	cfg, err := reader.read(ctx)
 	if err != nil {
-		return wkdb.EmptyChannelClusterConfig, err
+		return cfg, fmt.Errorf("slot %d config: %w", slotID, err)
 	}
-	if !before.Exists || !before.Ready || before.LeaderID != s.opts.ConfigOptions.NodeId || before.AppliedIndex < before.CommittedIndex || s.cfgServer.SlotLeaderId(slotID) != before.LeaderID {
-		return wkdb.EmptyChannelClusterConfig, ErrConversationReadRetry
-	}
-	cfg, readErr := s.db.GetChannelClusterConfig(id, typ)
-	after, err := s.slotServer.ReadLeaderState(ctx, slotID)
-	if err != nil {
-		return wkdb.EmptyChannelClusterConfig, err
-	}
-	// Also reject metadata written/applied concurrently with this DB read.
-	if before != after || s.cfgServer.SlotLeaderId(slotID) != before.LeaderID {
-		return wkdb.EmptyChannelClusterConfig, ErrConversationReadRetry
-	}
-	if err := ctx.Err(); err != nil {
-		return wkdb.EmptyChannelClusterConfig, err
-	}
-	return cfg, readErr
+	return cfg, nil
 }
 
 func (r *rpcServer) handleConversationRead(c *wkserver.Context, configOnly bool) {
@@ -283,10 +293,11 @@ func (r *rpcServer) handleConversationRead(c *wkserver.Context, configOnly bool)
 	}
 	ctx, cancel := context.WithTimeout(r.s.cancelCtx, budget)
 	defer cancel()
-	resp := conversationReadResponse{Version: 1}
+	resp := conversationReadResponse{Version: conversationReadVersion}
 	if configOnly {
 		cfg, err := r.s.loadConversationConfigLocal(ctx, req.ChannelID, req.ChannelType)
 		if err != nil && !errors.Is(err, wkdb.ErrNotFound) {
+			r.s.Debug("conversation config read failed", zap.String("channelId", req.ChannelID), zap.Uint8("channelType", req.ChannelType), zap.Error(err))
 			c.WriteErr(ErrConversationReadRetry)
 			return
 		}
@@ -298,6 +309,7 @@ func (r *rpcServer) handleConversationRead(c *wkserver.Context, configOnly bool)
 		}
 		seq, err := r.s.conversationReader().readLocal(ctx, req.Expected)
 		if err != nil {
+			r.s.Debug("conversation boundary read failed", zap.String("channelId", req.ChannelID), zap.Uint8("channelType", req.ChannelType), zap.Error(err))
 			c.WriteErr(ErrConversationReadRetry)
 			return
 		}

--- a/pkg/cluster/cluster/conversation_read.go
+++ b/pkg/cluster/cluster/conversation_read.go
@@ -1,0 +1,312 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/raftgroup"
+	"github.com/WuKongIM/WuKongIM/pkg/wkdb"
+	"github.com/WuKongIM/WuKongIM/pkg/wkserver"
+	"github.com/WuKongIM/WuKongIM/pkg/wkserver/proto"
+	"github.com/WuKongIM/WuKongIM/pkg/wkutil"
+)
+
+var ErrConversationReadRetry = errors.New("retry required")
+
+const (
+	conversationConfigPath   = "/rpc/channel/conversationConfig/v1"
+	conversationBoundaryPath = "/rpc/channel/conversationBoundary/v1"
+)
+
+type conversationReadRequest struct {
+	ChannelID   string                    `json:"channel_id"`
+	ChannelType uint8                     `json:"channel_type"`
+	Expected    wkdb.ChannelClusterConfig `json:"expected"`
+	Budget      time.Duration             `json:"budget"`
+}
+
+// Version and required payload fields prevent an old/malformed success response
+// from being mistaken for an authoritative zero. Existing RPCs stay unchanged.
+type conversationReadResponse struct {
+	Version  int                        `json:"version"`
+	Config   *wkdb.ChannelClusterConfig `json:"config,omitempty"`
+	Sequence *uint64                    `json:"sequence,omitempty"`
+}
+
+type conversationReader struct {
+	nodeID uint64
+	load   func(context.Context, string, uint8) (wkdb.ChannelClusterConfig, error)
+	state  func(context.Context, string, uint8) (raftgroup.ReadState, error)
+	local  func(string, uint8) (uint64, uint64, error)
+	remote func(context.Context, uint64, string, conversationReadRequest) (conversationReadResponse, error)
+}
+
+func (s *Server) conversationReader() conversationReader {
+	return conversationReader{
+		nodeID: s.opts.ConfigOptions.NodeId,
+		load:   s.loadConversationConfig,
+		state:  s.channelServer.ReadLeaderState,
+		local:  s.db.GetChannelLastMessageSeq,
+		remote: s.requestConversationRead,
+	}
+}
+
+// GetChannelLastMessageSeq resolves the channel's message owner independently
+// of the UID slot owning the conversation. The complete read has one budget and
+// at most one retry, always reloading metadata instead of using a local fallback.
+func (s *Server) GetChannelLastMessageSeq(ctx context.Context, channelID string, channelType uint8) (uint64, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.conversationReadTimeout())
+	defer cancel()
+	return s.conversationReader().latest(ctx, channelID, channelType)
+}
+
+func (r conversationReader) latest(ctx context.Context, id string, typ uint8) (uint64, error) {
+	seenConfig := false
+	for attempt := 0; attempt < 2; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		// Leave time to refresh the route even when the first peer times out.
+		attemptCtx := ctx
+		cancel := func() {}
+		if deadline, ok := ctx.Deadline(); ok {
+			attemptCtx, cancel = context.WithTimeout(ctx, time.Until(deadline)/time.Duration(2-attempt))
+		}
+		seq, found, err := r.attempt(attemptCtx, id, typ, !seenConfig)
+		cancel()
+		seenConfig = seenConfig || found
+		if err == nil {
+			return seq, ctx.Err()
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	return 0, ErrConversationReadRetry
+}
+
+func (r conversationReader) attempt(ctx context.Context, id string, typ uint8, allowMissing bool) (uint64, bool, error) {
+	cfg, err := r.load(ctx, id, typ)
+	if errors.Is(err, wkdb.ErrNotFound) && allowMissing {
+		// Preserve v2.2.5's unused-channel semantics without creating metadata.
+		return 0, false, ctx.Err()
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	if !validConversationConfig(cfg, id, typ) {
+		return 0, true, ErrConversationReadRetry
+	}
+	var seq uint64
+	if cfg.LeaderId == r.nodeID {
+		seq, err = r.readLocal(ctx, cfg)
+	} else {
+		var resp conversationReadResponse
+		resp, err = r.remote(ctx, cfg.LeaderId, conversationBoundaryPath,
+			conversationReadRequest{ChannelID: id, ChannelType: typ, Expected: cfg})
+		if err == nil {
+			if resp.Version != 1 || resp.Sequence == nil || resp.Config == nil || !cfg.Equal(*resp.Config) {
+				err = ErrConversationReadRetry
+			} else {
+				seq = *resp.Sequence
+			}
+		}
+	}
+	if err != nil {
+		return 0, true, err
+	}
+	after, err := r.load(ctx, id, typ)
+	if err != nil {
+		return 0, true, err
+	}
+	if !cfg.Equal(after) {
+		return 0, true, ErrConversationReadRetry
+	}
+	return seq, true, ctx.Err()
+}
+
+func validConversationConfig(cfg wkdb.ChannelClusterConfig, id string, typ uint8) bool {
+	return cfg.ChannelId == id && cfg.ChannelType == typ && cfg.LeaderId != 0 && cfg.Term != 0 &&
+		cfg.Status == wkdb.ChannelClusterStatusNormal &&
+		wkutil.ArrayContainsUint64(cfg.Replicas, cfg.LeaderId) &&
+		!wkutil.ArrayContainsUint64(cfg.Learners, cfg.LeaderId)
+}
+
+func (r conversationReader) readLocal(ctx context.Context, expected wkdb.ChannelClusterConfig) (uint64, error) {
+	if !validConversationConfig(expected, expected.ChannelId, expected.ChannelType) || expected.LeaderId != r.nodeID {
+		return 0, ErrConversationReadRetry
+	}
+	id, typ := expected.ChannelId, expected.ChannelType
+	cfg, err := r.load(ctx, id, typ)
+	if err != nil {
+		return 0, err
+	}
+	if !cfg.Equal(expected) {
+		return 0, ErrConversationReadRetry
+	}
+	before, err := r.state(ctx, id, typ)
+	if err != nil {
+		return 0, err
+	}
+	if !conversationStateReady(before, cfg) {
+		return 0, ErrConversationReadRetry
+	}
+	seq, _, err := r.local(id, typ)
+	if err != nil {
+		return 0, err
+	}
+	after, err := r.state(ctx, id, typ)
+	if err != nil {
+		return 0, err
+	}
+	if before.Exists != after.Exists || !conversationStateReady(after, cfg) {
+		return 0, ErrConversationReadRetry
+	}
+	latest, err := r.load(ctx, id, typ)
+	if err != nil {
+		return 0, err
+	}
+	if !cfg.Equal(latest) {
+		return 0, ErrConversationReadRetry
+	}
+	return seq, ctx.Err()
+}
+
+func conversationStateReady(state raftgroup.ReadState, cfg wkdb.ChannelClusterConfig) bool {
+	if !state.Exists {
+		// Idle channels are automatically destroyed in this architecture. Reading
+		// their designated owner's durable tail must not wake them. A dormant
+		// channel in transfer cannot establish that it finished draining.
+		return cfg.MigrateFrom == 0 && cfg.MigrateTo == 0
+	}
+	return state.Ready && state.LeaderID == cfg.LeaderId && state.Term == cfg.Term && state.ConfigVersion == cfg.ConfVersion
+}
+
+func (s *Server) conversationReadTimeout() time.Duration {
+	if s.opts.ReqTimeout > 0 {
+		return s.opts.ReqTimeout
+	}
+	return 5 * time.Second
+}
+
+func (s *Server) requestConversationRead(ctx context.Context, nodeID uint64, path string, req conversationReadRequest) (conversationReadResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return conversationReadResponse{}, err
+	}
+	req.Budget = s.conversationReadTimeout()
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) < req.Budget {
+		req.Budget = time.Until(deadline)
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return conversationReadResponse{}, err
+	}
+	resp, err := s.RequestWithContext(ctx, nodeID, path, data)
+	if err != nil {
+		return conversationReadResponse{}, err
+	}
+	if resp == nil || resp.Status != proto.StatusOK {
+		return conversationReadResponse{}, ErrConversationReadRetry
+	}
+	var result conversationReadResponse
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		return result, err
+	}
+	if result.Version != 1 {
+		return result, ErrConversationReadRetry
+	}
+	return result, ctx.Err()
+}
+
+func (s *Server) loadConversationConfig(ctx context.Context, id string, typ uint8) (wkdb.ChannelClusterConfig, error) {
+	if err := ctx.Err(); err != nil {
+		return wkdb.EmptyChannelClusterConfig, err
+	}
+	leader, err := s.SlotLeaderIdOfChannel(id, typ)
+	if err != nil {
+		return wkdb.EmptyChannelClusterConfig, err
+	}
+	if leader == s.opts.ConfigOptions.NodeId {
+		return s.loadConversationConfigLocal(ctx, id, typ)
+	}
+	resp, err := s.requestConversationRead(ctx, leader, conversationConfigPath, conversationReadRequest{ChannelID: id, ChannelType: typ})
+	if err != nil {
+		return wkdb.EmptyChannelClusterConfig, err
+	}
+	if resp.Config == nil {
+		return wkdb.EmptyChannelClusterConfig, ErrConversationReadRetry
+	}
+	if wkdb.IsEmptyChannelClusterConfig(*resp.Config) {
+		return wkdb.EmptyChannelClusterConfig, wkdb.ErrNotFound
+	}
+	if resp.Config.ChannelId != id || resp.Config.ChannelType != typ {
+		return wkdb.EmptyChannelClusterConfig, ErrConversationReadRetry
+	}
+	return *resp.Config, nil
+}
+
+func (s *Server) loadConversationConfigLocal(ctx context.Context, id string, typ uint8) (wkdb.ChannelClusterConfig, error) {
+	slotID := s.getSlotId(id)
+	before, err := s.slotServer.ReadLeaderState(ctx, slotID)
+	if err != nil {
+		return wkdb.EmptyChannelClusterConfig, err
+	}
+	if !before.Exists || !before.Ready || before.LeaderID != s.opts.ConfigOptions.NodeId || before.AppliedIndex < before.CommittedIndex || s.cfgServer.SlotLeaderId(slotID) != before.LeaderID {
+		return wkdb.EmptyChannelClusterConfig, ErrConversationReadRetry
+	}
+	cfg, readErr := s.db.GetChannelClusterConfig(id, typ)
+	after, err := s.slotServer.ReadLeaderState(ctx, slotID)
+	if err != nil {
+		return wkdb.EmptyChannelClusterConfig, err
+	}
+	// Also reject metadata written/applied concurrently with this DB read.
+	if before != after || s.cfgServer.SlotLeaderId(slotID) != before.LeaderID {
+		return wkdb.EmptyChannelClusterConfig, ErrConversationReadRetry
+	}
+	if err := ctx.Err(); err != nil {
+		return wkdb.EmptyChannelClusterConfig, err
+	}
+	return cfg, readErr
+}
+
+func (r *rpcServer) handleConversationRead(c *wkserver.Context, configOnly bool) {
+	var req conversationReadRequest
+	if err := json.Unmarshal(c.Body(), &req); err != nil || req.ChannelID == "" || req.ChannelType == 0 || req.Budget <= 0 {
+		c.WriteErr(ErrConversationReadRetry)
+		return
+	}
+	budget := r.s.conversationReadTimeout()
+	if req.Budget < budget {
+		budget = req.Budget
+	}
+	ctx, cancel := context.WithTimeout(r.s.cancelCtx, budget)
+	defer cancel()
+	resp := conversationReadResponse{Version: 1}
+	if configOnly {
+		cfg, err := r.s.loadConversationConfigLocal(ctx, req.ChannelID, req.ChannelType)
+		if err != nil && !errors.Is(err, wkdb.ErrNotFound) {
+			c.WriteErr(ErrConversationReadRetry)
+			return
+		}
+		resp.Config = &cfg
+	} else {
+		if req.Expected.ChannelId != req.ChannelID || req.Expected.ChannelType != req.ChannelType {
+			c.WriteErr(ErrConversationReadRetry)
+			return
+		}
+		seq, err := r.s.conversationReader().readLocal(ctx, req.Expected)
+		if err != nil {
+			c.WriteErr(ErrConversationReadRetry)
+			return
+		}
+		resp.Config, resp.Sequence = &req.Expected, &seq
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		c.WriteErr(ErrConversationReadRetry)
+		return
+	}
+	c.Write(data)
+}

--- a/pkg/cluster/cluster/conversation_read_integration_test.go
+++ b/pkg/cluster/cluster/conversation_read_integration_test.go
@@ -113,7 +113,7 @@ func TestConversationReadRPC(t *testing.T) {
 		require.ErrorIs(t, err, ErrConversationReadRetry)
 		require.Zero(t, seq, "an unsupported metadata RPC is not an empty channel")
 	})
-	for _, body := range []string{"not supported", `{}`, `{"version":1}`, `{"version":1,"sequence":-1}`} {
+	for _, body := range []string{"not supported", `{}`, `{"version":1,"sequence":42,"config":{}}`, `{"version":2}`, `{"version":2,"sequence":-1}`} {
 		t.Run(body, func(t *testing.T) {
 			leader.netServer.Route(conversationBoundaryPath, func(c *wkserver.Context) {
 				if body == "not supported" {
@@ -165,10 +165,19 @@ func TestConversationReadSingleNode(t *testing.T) {
 	require.NoError(t, s.db.AppendMessages(cfg.ChannelId, cfg.ChannelType, []wkdb.Message{{Term: 1, RecvPacket: wkproto.RecvPacket{
 		ChannelID: cfg.ChannelId, ChannelType: cfg.ChannelType, MessageID: 42, MessageSeq: 42, Payload: []byte("message"),
 	}}}))
+	// Legacy recovery has no maintained durable commit marker. Pin that
+	// limitation explicitly: waking this pre-existing tail is not proof that
+	// its history reached quorum (see docs/conversation-boundary-reads.md).
+	persistedApplied, err := s.db.GetChannelAppliedIndex(cfg.ChannelId, cfg.ChannelType)
+	require.NoError(t, err)
+	require.Zero(t, persistedApplied)
 	for _, active := range []bool{false, true} {
 		t.Run(fmt.Sprintf("active=%t", active), func(t *testing.T) {
 			if active {
 				require.NoError(t, s.channelServer.WakeLeaderIfNeed(cfg))
+				state, err := s.channelServer.ReadLeaderState(ctx, cfg.ChannelId, cfg.ChannelType)
+				require.NoError(t, err)
+				require.Equal(t, uint64(42), state.CommittedIndex, "legacy recovery seeds committed from the stored tail")
 			}
 			seq, err := s.GetChannelLastMessageSeq(ctx, cfg.ChannelId, cfg.ChannelType)
 			require.NoError(t, err)

--- a/pkg/cluster/cluster/conversation_read_integration_test.go
+++ b/pkg/cluster/cluster/conversation_read_integration_test.go
@@ -1,0 +1,179 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/pkg/cluster/node/clusterconfig"
+	rafttypes "github.com/WuKongIM/WuKongIM/pkg/raft/types"
+	"github.com/WuKongIM/WuKongIM/pkg/trace"
+	"github.com/WuKongIM/WuKongIM/pkg/wkdb"
+	"github.com/WuKongIM/WuKongIM/pkg/wkserver"
+	"github.com/WuKongIM/WuKongIM/pkg/wkserver/proto"
+	"github.com/WuKongIM/WuKongIM/pkg/wkutil"
+	wkproto "github.com/WuKongIM/WuKongIMGoProto"
+	"github.com/stretchr/testify/require"
+)
+
+// Real TCP RPC + Pebble: the conversation owner has sequence 7 while the
+// channel's sole message replica has 42. No manager HTTP endpoint is available.
+func TestConversationReadRPC(t *testing.T) {
+	previousTrace := trace.GlobalTrace
+	trace.SetGlobalTrace(trace.New(context.Background(), trace.NewOptions()))
+	t.Cleanup(func() { trace.SetGlobalTrace(previousTrace) })
+	addresses := make(map[uint64]string)
+	for id := uint64(1); id <= 2; id++ {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		addresses[id] = listener.Addr().String()
+		require.NoError(t, listener.Close())
+	}
+	servers := make([]*Server, 0, 2)
+	for id := uint64(1); id <= 2; id++ {
+		config := newTestOptions(t, id, addresses, clusterconfig.WithSlotCount(2), clusterconfig.WithSlotMaxReplicaCount(2))
+		s := New(NewOptions(WithAddr("tcp://"+addresses[id]), WithConfigOptions(config), WithDataDir(t.TempDir()),
+			WithDBWKDbShardNum(1), WithDBSlotShardNum(1), WithDBWKDbMemTableSize(1<<20), WithDBSlotMemTableSize(1<<20)))
+		require.NoError(t, s.Start())
+		t.Cleanup(s.Stop)
+		servers = append(servers, s)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	for _, s := range servers {
+		require.NoError(t, s.WaitAllSlotReady(ctx, 2))
+	}
+	owner, leader := servers[0], servers[1]
+	// Choose metadata owned by node 1, forcing node 2 to fetch it over RPC.
+	var id string
+	for i := 0; i < 1000; i++ {
+		candidate := fmt.Sprintf("boundary-%d", i)
+		if owner.cfgServer.SlotLeaderId(owner.getSlotId(candidate)) == 1 {
+			id = candidate
+			break
+		}
+	}
+	require.NotEmpty(t, id)
+	cfg := wkdb.ChannelClusterConfig{ChannelId: id, ChannelType: 2, LeaderId: 2, Term: 1, ConfVersion: 1,
+		ReplicaMaxCount: 1, Replicas: []uint64{2}, Status: wkdb.ChannelClusterStatusNormal}
+	require.NoError(t, owner.db.SaveChannelClusterConfig(cfg))
+	for i, s := range servers {
+		seq := uint32(7)
+		if i == 1 {
+			seq = 42
+		}
+		require.NoError(t, s.db.AppendMessages(id, 2, []wkdb.Message{{Term: 1, RecvPacket: wkproto.RecvPacket{
+			ChannelID: id, ChannelType: 2, MessageID: int64(seq), MessageSeq: seq, Payload: []byte("message"),
+		}}}))
+	}
+	t.Run("idle leader", func(t *testing.T) {
+		seq, err := owner.GetChannelLastMessageSeq(ctx, id, 2)
+		require.NoError(t, err)
+		require.Equal(t, uint64(42), seq)
+		require.False(t, leader.channelServer.ExistChannel(id, 2), "read must not wake the channel")
+	})
+	t.Run("active leader", func(t *testing.T) {
+		require.NoError(t, leader.channelServer.WakeLeaderIfNeed(cfg))
+		seq, err := owner.GetChannelLastMessageSeq(ctx, id, 2)
+		require.NoError(t, err)
+		require.Equal(t, uint64(42), seq)
+		seq, err = leader.GetChannelLastMessageSeq(ctx, id, 2)
+		require.NoError(t, err)
+		require.Equal(t, uint64(42), seq)
+	})
+	t.Run("stale epoch", func(t *testing.T) {
+		stale := cfg
+		stale.Term++
+		_, err := owner.requestConversationRead(ctx, 2, conversationBoundaryPath,
+			conversationReadRequest{ChannelID: id, ChannelType: 2, Expected: stale})
+		require.ErrorIs(t, err, ErrConversationReadRetry)
+	})
+	t.Run("wrong node", func(t *testing.T) {
+		_, err := leader.requestConversationRead(ctx, 1, conversationBoundaryPath,
+			conversationReadRequest{ChannelID: id, ChannelType: 2, Expected: cfg})
+		require.ErrorIs(t, err, ErrConversationReadRetry)
+	})
+	t.Run("missing metadata", func(t *testing.T) {
+		seq, err := leader.GetChannelLastMessageSeq(ctx, "never-created", 2)
+		require.NoError(t, err)
+		require.Zero(t, seq)
+		_, err = owner.db.GetChannelClusterConfig("never-created", 2)
+		require.ErrorIs(t, err, wkdb.ErrNotFound)
+		_, err = leader.db.GetChannelClusterConfig("never-created", 2)
+		require.ErrorIs(t, err, wkdb.ErrNotFound)
+	})
+	t.Run("old metadata peer", func(t *testing.T) {
+		owner.netServer.Route(conversationConfigPath, func(c *wkserver.Context) {
+			c.WriteStatus(proto.StatusNotFound)
+		})
+		defer owner.netServer.Route(conversationConfigPath, func(c *wkserver.Context) { owner.rpcServer.handleConversationRead(c, true) })
+		seq, err := leader.GetChannelLastMessageSeq(ctx, id, 2)
+		require.ErrorIs(t, err, ErrConversationReadRetry)
+		require.Zero(t, seq, "an unsupported metadata RPC is not an empty channel")
+	})
+	for _, body := range []string{"not supported", `{}`, `{"version":1}`, `{"version":1,"sequence":-1}`} {
+		t.Run(body, func(t *testing.T) {
+			leader.netServer.Route(conversationBoundaryPath, func(c *wkserver.Context) {
+				if body == "not supported" {
+					c.WriteStatus(proto.StatusNotFound)
+				} else {
+					c.Write([]byte(body))
+				}
+			})
+			defer leader.netServer.Route(conversationBoundaryPath, func(c *wkserver.Context) { leader.rpcServer.handleConversationRead(c, false) })
+			seq, err := owner.GetChannelLastMessageSeq(ctx, id, 2)
+			require.ErrorIs(t, err, ErrConversationReadRetry)
+			require.Zero(t, seq)
+		})
+	}
+	t.Run("runtime follower", func(t *testing.T) {
+		// Metadata still designates node 2, but its runtime has stepped down.
+		leader.channelServer.AddEvent(wkutil.ChannelToKey(id, 2), rafttypes.Event{Type: rafttypes.ConfChange,
+			Config: rafttypes.Config{Leader: 1, Term: 2, Version: 2, Role: rafttypes.RoleFollower, Replicas: []uint64{1, 2}}})
+		require.Eventually(t, func() bool {
+			state, err := leader.channelServer.ReadLeaderState(ctx, id, 2)
+			return err == nil && !state.Ready && state.Term == 2
+		}, time.Second, time.Millisecond)
+		seq, err := owner.GetChannelLastMessageSeq(ctx, id, 2)
+		require.ErrorIs(t, err, ErrConversationReadRetry)
+		require.Zero(t, seq)
+	})
+}
+
+func TestConversationReadSingleNode(t *testing.T) {
+	previousTrace := trace.GlobalTrace
+	trace.SetGlobalTrace(trace.New(context.Background(), trace.NewOptions()))
+	t.Cleanup(func() { trace.SetGlobalTrace(previousTrace) })
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	address := listener.Addr().String()
+	require.NoError(t, listener.Close())
+	// Standalone deployments leave InitNodes empty so the initial leader is self.
+	config := newTestOptions(t, 1, nil, clusterconfig.WithSlotCount(1), clusterconfig.WithSlotMaxReplicaCount(1))
+	s := New(NewOptions(WithAddr("tcp://"+address), WithConfigOptions(config), WithDataDir(t.TempDir()),
+		WithDBWKDbShardNum(1), WithDBSlotShardNum(1), WithDBWKDbMemTableSize(1<<20), WithDBSlotMemTableSize(1<<20)))
+	require.NoError(t, s.Start())
+	t.Cleanup(s.Stop)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	require.NoError(t, s.WaitAllSlotReady(ctx, 1))
+	cfg := wkdb.ChannelClusterConfig{ChannelId: "single-node", ChannelType: 2, LeaderId: 1, Term: 1, ConfVersion: 1,
+		ReplicaMaxCount: 1, Replicas: []uint64{1}, Status: wkdb.ChannelClusterStatusNormal}
+	require.NoError(t, s.db.SaveChannelClusterConfig(cfg))
+	require.NoError(t, s.db.AppendMessages(cfg.ChannelId, cfg.ChannelType, []wkdb.Message{{Term: 1, RecvPacket: wkproto.RecvPacket{
+		ChannelID: cfg.ChannelId, ChannelType: cfg.ChannelType, MessageID: 42, MessageSeq: 42, Payload: []byte("message"),
+	}}}))
+	for _, active := range []bool{false, true} {
+		t.Run(fmt.Sprintf("active=%t", active), func(t *testing.T) {
+			if active {
+				require.NoError(t, s.channelServer.WakeLeaderIfNeed(cfg))
+			}
+			seq, err := s.GetChannelLastMessageSeq(ctx, cfg.ChannelId, cfg.ChannelType)
+			require.NoError(t, err)
+			require.Equal(t, uint64(42), seq)
+			require.Equal(t, active, s.channelServer.ExistChannel(cfg.ChannelId, cfg.ChannelType))
+		})
+	}
+}

--- a/pkg/cluster/cluster/conversation_read_test.go
+++ b/pkg/cluster/cluster/conversation_read_test.go
@@ -26,7 +26,7 @@ func boundaryReader(t *testing.T, cfg *wkdb.ChannelClusterConfig) conversationRe
 			return *cfg, ctx.Err()
 		},
 		state: func(context.Context, string, uint8) (raftgroup.ReadState, error) {
-			return raftgroup.ReadState{Exists: true, Ready: true, LeaderID: cfg.LeaderId, Term: cfg.Term, ConfigVersion: cfg.ConfVersion}, nil
+			return raftgroup.ReadState{Exists: true, Ready: true, LeaderID: cfg.LeaderId, Term: cfg.Term, ConfigVersion: cfg.ConfVersion, CommittedIndex: 42, AppliedIndex: 42}, nil
 		},
 		local: func(string, uint8) (uint64, uint64, error) {
 			t.Fatal("must not read the UID owner's local tail")
@@ -37,7 +37,7 @@ func boundaryReader(t *testing.T, cfg *wkdb.ChannelClusterConfig) conversationRe
 			require.Equal(t, conversationBoundaryPath, path)
 			require.Equal(t, *cfg, req.Expected)
 			seq, copy := uint64(42), *cfg
-			return conversationReadResponse{Version: 1, Sequence: &seq, Config: &copy}, ctx.Err()
+			return conversationReadResponse{Version: conversationReadVersion, Sequence: &seq, Config: &copy}, ctx.Err()
 		},
 	}
 }
@@ -239,4 +239,49 @@ func TestConversationReadServingState(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConversationReadCommittedBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		name                      string
+		tail, before, after, want uint64
+	}{
+		{"uncommitted suffix", 42, 41, 41, 41},
+		{"nothing committed", 42, 0, 0, 0},
+		{"commit during read", 42, 41, 42, 42},
+		{"tail below commit", 40, 41, 41, 40},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := boundaryConfig()
+			r := boundaryReader(t, &cfg)
+			r.nodeID = cfg.LeaderId
+			calls := 0
+			r.state = func(context.Context, string, uint8) (raftgroup.ReadState, error) {
+				calls++
+				committed := tc.before
+				if calls > 1 {
+					committed = tc.after
+				}
+				return raftgroup.ReadState{Exists: true, Ready: true, LeaderID: cfg.LeaderId, Term: cfg.Term, ConfigVersion: cfg.ConfVersion, CommittedIndex: committed}, nil
+			}
+			r.local = func(string, uint8) (uint64, uint64, error) { return tc.tail, 0, nil }
+			seq, err := r.readLocal(context.Background(), cfg)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, seq)
+		})
+	}
+}
+
+func TestConversationReaderRetainsFailureCause(t *testing.T) {
+	cfg := boundaryConfig()
+	r := boundaryReader(t, &cfg)
+	r.remote = func(context.Context, uint64, string, conversationReadRequest) (conversationReadResponse, error) {
+		return conversationReadResponse{}, errors.New("connection reset")
+	}
+	_, err := r.latest(context.Background(), cfg.ChannelId, cfg.ChannelType)
+	require.ErrorIs(t, err, ErrConversationReadRetry)
+	require.ErrorContains(t, err, "connection reset")
+	require.ErrorContains(t, err, "channel leader 4")
+	require.ErrorContains(t, err, "attempt 2")
+	require.ErrorContains(t, err, cfg.ChannelId)
 }

--- a/pkg/cluster/cluster/conversation_read_test.go
+++ b/pkg/cluster/cluster/conversation_read_test.go
@@ -1,0 +1,242 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/raftgroup"
+	"github.com/WuKongIM/WuKongIM/pkg/wkdb"
+	"github.com/stretchr/testify/require"
+)
+
+func boundaryConfig() wkdb.ChannelClusterConfig {
+	return wkdb.ChannelClusterConfig{ChannelId: "alice@bob", ChannelType: 1, LeaderId: 4, Term: 2,
+		ConfVersion: 10, Replicas: []uint64{4, 5}, Status: wkdb.ChannelClusterStatusNormal}
+}
+
+func boundaryReader(t *testing.T, cfg *wkdb.ChannelClusterConfig) conversationReader {
+	t.Helper()
+	return conversationReader{
+		nodeID: 1,
+		load: func(ctx context.Context, id string, typ uint8) (wkdb.ChannelClusterConfig, error) {
+			require.Equal(t, cfg.ChannelId, id)
+			require.Equal(t, cfg.ChannelType, typ)
+			return *cfg, ctx.Err()
+		},
+		state: func(context.Context, string, uint8) (raftgroup.ReadState, error) {
+			return raftgroup.ReadState{Exists: true, Ready: true, LeaderID: cfg.LeaderId, Term: cfg.Term, ConfigVersion: cfg.ConfVersion}, nil
+		},
+		local: func(string, uint8) (uint64, uint64, error) {
+			t.Fatal("must not read the UID owner's local tail")
+			return 0, 0, nil
+		},
+		remote: func(ctx context.Context, node uint64, path string, req conversationReadRequest) (conversationReadResponse, error) {
+			require.Equal(t, cfg.LeaderId, node)
+			require.Equal(t, conversationBoundaryPath, path)
+			require.Equal(t, *cfg, req.Expected)
+			seq, copy := uint64(42), *cfg
+			return conversationReadResponse{Version: 1, Sequence: &seq, Config: &copy}, ctx.Err()
+		},
+	}
+}
+
+func TestConversationReaderRemote(t *testing.T) {
+	cfg := boundaryConfig()
+	r := boundaryReader(t, &cfg)
+	seq, err := r.latest(context.Background(), cfg.ChannelId, cfg.ChannelType)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), seq)
+}
+
+func TestConversationReaderRefreshesRoute(t *testing.T) {
+	for _, trigger := range []string{"leader", "term", "config", "transport", "metadata", "timeout"} {
+		t.Run(trigger, func(t *testing.T) {
+			cfg := boundaryConfig()
+			r := boundaryReader(t, &cfg)
+			calls := 0
+			remote, load := r.remote, r.load
+			if trigger == "metadata" {
+				r.load = func(ctx context.Context, id string, typ uint8) (wkdb.ChannelClusterConfig, error) {
+					calls++
+					if calls == 1 {
+						return wkdb.EmptyChannelClusterConfig, errors.New("slot leader unavailable")
+					}
+					return load(ctx, id, typ)
+				}
+			} else {
+				r.remote = func(ctx context.Context, node uint64, path string, req conversationReadRequest) (conversationReadResponse, error) {
+					calls++
+					resp, err := remote(ctx, node, path, req)
+					if calls == 1 {
+						switch trigger {
+						case "leader":
+							cfg.LeaderId = 5
+						case "term":
+							cfg.Term++
+						case "config":
+							cfg.ConfVersion++
+						case "transport":
+							cfg.LeaderId = 5
+							return conversationReadResponse{}, errors.New("connection reset")
+						case "timeout":
+							<-ctx.Done()
+							cfg.LeaderId = 5
+							return conversationReadResponse{}, ctx.Err()
+						}
+					}
+					return resp, err
+				}
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+			seq, err := r.latest(ctx, cfg.ChannelId, cfg.ChannelType)
+			require.NoError(t, err)
+			require.Equal(t, uint64(42), seq)
+			if trigger != "metadata" {
+				require.Equal(t, 2, calls)
+			}
+		})
+	}
+}
+
+func TestConversationReaderFailsClosed(t *testing.T) {
+	for _, failure := range []string{"old peer", "missing sequence", "missing config", "wrong epoch", "transport", "churn", "disappeared", "candidate", "no leader", "learner leader", "storage"} {
+		t.Run(failure, func(t *testing.T) {
+			cfg := boundaryConfig()
+			r := boundaryReader(t, &cfg)
+			calls := 0
+			remote, load := r.remote, r.load
+			r.remote = func(ctx context.Context, node uint64, path string, req conversationReadRequest) (conversationReadResponse, error) {
+				calls++
+				resp, err := remote(ctx, node, path, req)
+				switch failure {
+				case "old peer":
+					resp.Version = 0
+				case "missing sequence":
+					resp.Sequence = nil
+				case "missing config":
+					resp.Config = nil
+				case "wrong epoch":
+					resp.Config.Term++
+				case "transport":
+					err = errors.New("unavailable")
+				case "churn":
+					cfg.Term++
+				}
+				return resp, err
+			}
+			switch failure {
+			case "disappeared":
+				r.load = func(ctx context.Context, id string, typ uint8) (wkdb.ChannelClusterConfig, error) {
+					if calls > 0 {
+						return wkdb.EmptyChannelClusterConfig, wkdb.ErrNotFound
+					}
+					return load(ctx, id, typ)
+				}
+			case "candidate":
+				cfg.Status = wkdb.ChannelClusterStatusCandidate
+			case "no leader":
+				cfg.LeaderId = 0
+			case "learner leader":
+				cfg.Learners = []uint64{cfg.LeaderId}
+			case "storage":
+				r.nodeID = cfg.LeaderId
+				r.local = func(string, uint8) (uint64, uint64, error) { return 0, 0, errors.New("disk error") }
+			}
+			seq, err := r.latest(context.Background(), cfg.ChannelId, cfg.ChannelType)
+			require.ErrorIs(t, err, ErrConversationReadRetry)
+			require.Zero(t, seq)
+			require.LessOrEqual(t, calls, 2)
+		})
+	}
+}
+
+func TestConversationReaderMissingAndCancellation(t *testing.T) {
+	cfg := boundaryConfig()
+	r := boundaryReader(t, &cfg)
+	loads := 0
+	r.load = func(ctx context.Context, _ string, _ uint8) (wkdb.ChannelClusterConfig, error) {
+		loads++
+		return wkdb.EmptyChannelClusterConfig, wkdb.ErrNotFound
+	}
+	seq, err := r.latest(context.Background(), cfg.ChannelId, cfg.ChannelType)
+	require.NoError(t, err)
+	require.Zero(t, seq)
+	require.Equal(t, 1, loads)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = r.latest(ctx, cfg.ChannelId, cfg.ChannelType)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, loads)
+	r.load = func(ctx context.Context, _ string, _ uint8) (wkdb.ChannelClusterConfig, error) {
+		<-ctx.Done()
+		return wkdb.EmptyChannelClusterConfig, ctx.Err()
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err = r.latest(ctx, cfg.ChannelId, cfg.ChannelType)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestConversationReadServingState(t *testing.T) {
+	for _, state := range []string{"leader", "idle", "follower", "wrong term", "wrong version", "draining", "removed during read", "demoted during read", "config changed", "wrong node", "idle transfer"} {
+		t.Run(state, func(t *testing.T) {
+			cfg := boundaryConfig()
+			r := boundaryReader(t, &cfg)
+			r.nodeID = cfg.LeaderId
+			reads, snapshots := 0, 0
+			r.local = func(string, uint8) (uint64, uint64, error) { reads++; return 42, 0, nil }
+			readState := r.state
+			r.state = func(ctx context.Context, id string, typ uint8) (raftgroup.ReadState, error) {
+				snapshots++
+				s, err := readState(ctx, id, typ)
+				switch state {
+				case "idle", "idle transfer":
+					s.Exists = false
+				case "follower":
+					s.Ready = false
+					s.LeaderID = 5
+				case "wrong term":
+					s.Term++
+				case "wrong version":
+					s.ConfigVersion++
+				case "draining":
+					s.Ready = false
+				case "removed during read":
+					if snapshots == 2 {
+						s.Exists = false
+					}
+				case "demoted during read":
+					if snapshots == 2 {
+						s.Ready = false
+					}
+				case "config changed":
+					if snapshots == 2 {
+						cfg.Term++
+					}
+				}
+				return s, err
+			}
+			if state == "wrong node" {
+				r.nodeID = 1
+			}
+			if state == "idle transfer" {
+				cfg.MigrateFrom, cfg.MigrateTo = 4, 5
+			}
+			seq, err := r.readLocal(context.Background(), cfg)
+			if state == "leader" || state == "idle" {
+				require.NoError(t, err)
+				require.Equal(t, uint64(42), seq)
+				require.Equal(t, 1, reads)
+			} else {
+				require.ErrorIs(t, err, ErrConversationReadRetry)
+				require.Zero(t, seq)
+				if state != "removed during read" && state != "demoted during read" && state != "config changed" {
+					require.Zero(t, reads)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cluster/cluster/rpc_server.go
+++ b/pkg/cluster/cluster/rpc_server.go
@@ -26,6 +26,8 @@ func newRpcServer(s *Server) *rpcServer {
 }
 
 func (r *rpcServer) setRoutes() {
+	r.s.netServer.Route(conversationConfigPath, func(c *wkserver.Context) { r.handleConversationRead(c, true) })
+	r.s.netServer.Route(conversationBoundaryPath, func(c *wkserver.Context) { r.handleConversationRead(c, false) })
 	// 频道提案
 	r.s.netServer.Route("/rpc/channel/propose", r.handleChannelPropose)
 

--- a/pkg/cluster/icluster/cluster.go
+++ b/pkg/cluster/icluster/cluster.go
@@ -63,6 +63,9 @@ type IClusterSlot interface {
 }
 
 type IClusterChannel interface {
+	// GetChannelLastMessageSeq reads a conversation boundary from the channel leader.
+	// It never creates a channel or falls back to a local follower.
+	GetChannelLastMessageSeq(ctx context.Context, channelID string, channelType uint8) (uint64, error)
 
 	// LeaderOfChannel 获取频道的领导节点 (如果频道分布式配置不存在则会创建新的分布式配置并提案)
 	LeaderOfChannel(channelId string, channelType uint8) (*types.Node, error)

--- a/pkg/cluster/slot/server.go
+++ b/pkg/cluster/slot/server.go
@@ -14,6 +14,10 @@ import (
 	"go.uber.org/zap"
 )
 
+func (s *Server) ReadLeaderState(ctx context.Context, slotID uint32) (raftgroup.ReadState, error) {
+	return s.raftGroup.ReadLeaderState(ctx, SlotIdToKey(slotID))
+}
+
 type Server struct {
 	raftGroup *raftgroup.RaftGroup
 	storage   *PebbleShardLogStorage

--- a/pkg/raft/raft/node_read.go
+++ b/pkg/raft/raft/node_read.go
@@ -1,0 +1,7 @@
+package raft
+
+// LeaderReadReady must be called on the owner's event loop, just like Step.
+// A leader draining proposals for transfer must not certify a read boundary.
+func (n *Node) LeaderReadReady() bool {
+	return n.IsLeader() && !n.stopPropose && !n.truncating
+}

--- a/pkg/raft/raft/node_read_test.go
+++ b/pkg/raft/raft/node_read_test.go
@@ -1,0 +1,23 @@
+package raft
+
+import (
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaderReadReady(t *testing.T) {
+	n := NewNode(0, types.RaftState{}, NewOptions(WithNodeId(1), WithReplicas([]uint64{1})))
+	require.True(t, n.LeaderReadReady())
+	n.stopPropose = true
+	require.False(t, n.LeaderReadReady())
+	n.stopPropose = false
+	n.truncating = true
+	require.False(t, n.LeaderReadReady())
+	n.truncating = false
+	n.BecomeFollower(2, 2)
+	require.False(t, n.LeaderReadReady())
+	n.BecomeLearner(2, 2)
+	require.False(t, n.LeaderReadReady())
+}

--- a/pkg/raft/raftgroup/raftgroup.go
+++ b/pkg/raft/raftgroup/raftgroup.go
@@ -14,10 +14,11 @@ import (
 )
 
 type RaftGroup struct {
-	raftList *linkedList
-	stopper  *syncutil.Stopper
-	opts     *Options
-	advanceC chan struct{}
+	raftList   *linkedList
+	stopper    *syncutil.Stopper
+	opts       *Options
+	advanceC   chan struct{}
+	readStateC chan readStateRequest
 
 	tmpRafts []IRaft
 	stopped  bool
@@ -38,6 +39,7 @@ func New(opts *Options) *RaftGroup {
 		stopper:           syncutil.NewStopper(),
 		opts:              opts,
 		advanceC:          make(chan struct{}, 1),
+		readStateC:        make(chan readStateRequest),
 		Log:               wklog.NewWKLog(fmt.Sprintf("RaftGroup[%s]", opts.LogPrefix)),
 		mq:                NewEventQueue(opts.ReceiveQueueLength, false, 0, 0),
 		wait:              newWait(),
@@ -164,6 +166,8 @@ func (rg *RaftGroup) loopEvent() {
 		case <-tk.C:
 			rg.ticks()
 		case <-rg.advanceC:
+		case req := <-rg.readStateC:
+			rg.handleReadState(req)
 		case <-rg.stopper.ShouldStop():
 			return
 		}

--- a/pkg/raft/raftgroup/read_state.go
+++ b/pkg/raft/raftgroup/read_state.go
@@ -1,0 +1,60 @@
+package raftgroup
+
+import (
+	"context"
+	"errors"
+)
+
+// ReadState is a scalar snapshot taken on the Raft event loop. It is a local
+// role/configuration check, not a quorum ReadIndex or a leader lease.
+type ReadState struct {
+	Exists         bool
+	LeaderID       uint64
+	Term           uint32
+	ConfigVersion  uint64
+	Ready          bool
+	CommittedIndex uint64
+	AppliedIndex   uint64
+}
+
+type readStateRequest struct {
+	key    string
+	result chan ReadState
+}
+
+// ReadLeaderState avoids racing Step/Tick when validating an authoritative read.
+func (rg *RaftGroup) ReadLeaderState(ctx context.Context, key string) (ReadState, error) {
+	if err := ctx.Err(); err != nil {
+		return ReadState{}, err
+	}
+	req := readStateRequest{key: key, result: make(chan ReadState, 1)}
+	select {
+	case rg.readStateC <- req:
+	case <-ctx.Done():
+		return ReadState{}, ctx.Err()
+	case <-rg.stopper.ShouldStop():
+		return ReadState{}, errors.New("raft group stopped")
+	}
+	select {
+	case state := <-req.result:
+		return state, ctx.Err()
+	case <-ctx.Done():
+		return ReadState{}, ctx.Err()
+	case <-rg.stopper.ShouldStop():
+		return ReadState{}, errors.New("raft group stopped")
+	}
+}
+
+func (rg *RaftGroup) handleReadState(req readStateRequest) {
+	var state ReadState
+	if r := rg.GetRaft(req.key); r != nil {
+		cfg := r.Config()
+		state = ReadState{Exists: true, LeaderID: cfg.Leader, Term: cfg.Term,
+			ConfigVersion: cfg.Version, CommittedIndex: r.CommittedIndex(), AppliedIndex: r.AppliedIndex()}
+		// Unknown implementations cannot certify that writes have not been fenced.
+		if reader, ok := r.(interface{ LeaderReadReady() bool }); ok {
+			state.Ready = reader.LeaderReadReady()
+		}
+	}
+	req.result <- state
+}

--- a/pkg/raft/raftgroup/read_state_test.go
+++ b/pkg/raft/raftgroup/read_state_test.go
@@ -1,0 +1,54 @@
+package raftgroup_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/raft"
+	"github.com/WuKongIM/WuKongIM/pkg/raft/raftgroup"
+	"github.com/WuKongIM/WuKongIM/pkg/raft/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadLeaderState(t *testing.T) {
+	rg := raftgroup.New(raftgroup.NewOptions(raftgroup.WithTickInterval(time.Hour)))
+	require.NoError(t, rg.Start())
+	defer rg.Stop()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	state, err := rg.ReadLeaderState(ctx, "idle")
+	require.NoError(t, err)
+	require.False(t, state.Exists)
+	n := raft.NewNode(0, types.RaftState{}, raft.NewOptions(raft.WithKey("channel"), raft.WithNodeId(1)))
+	rg.AddRaft(n)
+	cfg := types.Config{Leader: 1, Term: 2, Version: 10, Role: types.RoleLeader, Replicas: []uint64{1, 2}}
+	require.NoError(t, rg.AddEventWait("channel", types.Event{Type: types.ConfChange, Config: cfg}))
+	state, err = rg.ReadLeaderState(ctx, "channel")
+	require.NoError(t, err)
+	require.True(t, state.Exists)
+	require.True(t, state.Ready)
+	require.Equal(t, uint64(1), state.LeaderID)
+	require.Equal(t, uint32(2), state.Term)
+	require.Equal(t, uint64(10), state.ConfigVersion)
+	cfg.Leader, cfg.Term, cfg.Version, cfg.Role = 2, 3, 11, types.RoleFollower
+	require.NoError(t, rg.AddEventWait("channel", types.Event{Type: types.ConfChange, Config: cfg}))
+	state, err = rg.ReadLeaderState(ctx, "channel")
+	require.NoError(t, err)
+	require.False(t, state.Ready)
+	require.Equal(t, uint32(3), state.Term)
+	cancel()
+	_, err = rg.ReadLeaderState(ctx, "channel")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestReadLeaderStateUnstartedAndStopped(t *testing.T) {
+	rg := raftgroup.New(raftgroup.NewOptions(raftgroup.WithTickInterval(time.Hour)))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := rg.ReadLeaderState(ctx, "channel")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	rg.Stop()
+	_, err = rg.ReadLeaderState(context.Background(), "channel")
+	require.ErrorContains(t, err, "stopped")
+}


### PR DESCRIPTION
## Problem and behavior

On `fix/raft-orphan-learner-bugs`, `clearUnread`, `setUnread`, and `delete` run on the UID slot leader but previously read that node's local channel tail. A missing or lagging message replica could therefore produce a successful mutation with boundary 0 or 7 while the channel leader was at 42.

The three mutations now resolve the channel leader independently, validate its ownership/term/configuration/drain state, and use its message boundary. Active-channel results are capped at the post-read runtime committed index, so a newly appended but uncommitted suffix cannot advance the cursor. Writes stay on the UID slot leader. This PR adapts #35 to the v2.2.5 architecture and is based directly on `fix/raft-orphan-learner-bugs`, without importing main's refactor.

## Implementation

- Load existing channel configuration at its slot leader. Capture a fixed committed index, wait for apply to reach it within the request budget, and verify leadership around the DB read. Unrelated later slot writes do not force a retry or move the apply target.
- Validate the serving channel's leader, term, configuration version, and drain/truncation state before and after the message read. Raft snapshots run on the owning event loop.
- Bound active-channel results by `min(durableTail, postReadCommittedIndex)`. A first message committed during the read may be included.
- Refresh configuration and retry once after metadata, ownership, or transport failures. Return stable HTTP 503 retry responses when the read cannot be established, while retaining channel/attempt/peer details internally. Never fall back to the UID owner's local follower tail.
- Use version 2 configuration and boundary RPCs; malformed peers and version 1 experimental peers that return unbounded tails are rejected.
- Preserve monotonic read cursors, reject negative unread counts, and prevent zero-sequence underflow.

No schema, dependencies, configuration keys, or learner-election algorithms change. Ordinary conversation sync and unrelated RPCs retain their behavior.

## Compatibility and recovery limits

Dormant channels remain readable without creation or activation. **A dormant tail can contain a crash-residue uncommitted suffix.** The legacy runtime initializes its applied index from the durable tail and its committed index from that applied index, so simply waking/recovering the channel does not prove commitment either. The existing persistent applied-index field is not maintained by the channel pipeline. The active bound prevents newly appended in-flight suffixes from being returned; it does not repair this inherited recovery ambiguity. Reliable cold/dormant boundaries require a separate durable commit-marker and legacy-data recovery policy. The behavior and limitation are documented and pinned in tests; see [conversation-boundary-reads.md](docs/conversation-boundary-reads.md).

These ownership checks are not a quorum ReadIndex or leader lease and do not guarantee linearizability across every partition window. Missing metadata retains the branch's empty-tail behavior; main's 404/409 contract is not imported.

Upgraded callers reject old peers rather than use the previous protocol. Participating nodes must be upgraded for the complete fix; requests reaching old UID owners retain the old implementation until those owners are upgraded.

## Validation

Passed locally:

- HTTP/router + Store command-codec regressions for all three operations, personal/group channels, local tails 0/7 vs leader tail 42, remote errors, cancellation/timeout, arithmetic boundaries, and non-regressing cursors.
- Fixed apply-barrier tests with growing committed indexes, leadership changes while waiting/reading, cancellation/deadline, and storage errors.
- Real Raft + Pebble regressions: a blocked unrelated conversation apply waits then succeeds; a slot write during the metadata DB read succeeds; continuous slot proposals coexist with boundary reads; a real unacknowledged append at 42 with committed 41 returns 41.
- The three new controlled concurrency/commit regressions fail against the previous PR implementation via a Go overlay and pass with this fix.
- Real single-node and two-node TCP RPC reads, dormant/active behavior, stale epochs, demotion and old/malformed peers; committed-zero and commit-during-read cases.
- Focused race tests for API, reader, apply-barrier and Raft snapshots; vet for all changed packages; server build with `-buildvcs=false` (the enclosing local workspace has an invalid `.git`).

Full `go test -p 1 -timeout=120s ./...` was run and is not green on this legacy baseline. Unchanged-target comparisons previously reproduced listener conflicts (`internal/server`, `pkg/wknet`), a bitmap expectation (`internal/track`), connect-event timeout (`internal/user/event`), queue assertion/nil-pointer failures (`pkg/cluster/cluster`), and cache/storage assertions (`pkg/wkdb`). The unchanged `pkg/wkserver` suite also has timing-sensitive failures. These are recorded separately from the passing focused regressions; the full suite is not claimed as passing.

The five-node application first/second-round experiments and learner scale-out scenario have not been rerun for this PR. Live experiment deployments were not changed.

```bash
go test -p 1 -timeout=90s ./internal/api ./pkg/cluster/cluster ./pkg/raft/raft ./pkg/raft/raftgroup -run '^Test(Conversation|LeaderReadReady|ReadLeaderState)' -count=1
go test -race -p 1 ./internal/api ./pkg/cluster/cluster ./pkg/raft/raft ./pkg/raft/raftgroup -run '^Test(ConversationBoundary|ConversationRemoteFailure|ConversationInvalidArithmetic|ConversationSetUnreadBoundary|ConversationUnreadDoesNotRegress|ConversationReader|ConversationReadServingState|ConversationReadCommittedBoundary|ConversationConfig|LeaderReadReady|ReadLeaderState)' -count=1
```
