### PR TITLE
fix: derive raft config response roles from local membership

### DIFF
--- a/pkg/cluster/cluster/channel_config_failover_test.go
+++ b/pkg/cluster/cluster/channel_config_failover_test.go
@@ -1,0 +1,143 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/pkg/cluster/node/clusterconfig"
+	"github.com/WuKongIM/WuKongIM/pkg/trace"
+	"github.com/WuKongIM/WuKongIM/pkg/wkdb"
+	wkproto "github.com/WuKongIM/WuKongIMGoProto"
+	"github.com/stretchr/testify/require"
+)
+
+// Real TCP and Pebble: after losing one of three replicas, the surviving
+// follower must keep pulling logs when it receives the new leader's config.
+func TestChannelReplicationAfterLeaderConfigChange(t *testing.T) {
+	previousTrace := trace.GlobalTrace
+	trace.SetGlobalTrace(trace.New(context.Background(), trace.NewOptions()))
+	t.Cleanup(func() { trace.SetGlobalTrace(previousTrace) })
+	addresses := make(map[uint64]string)
+	for id := uint64(1); id <= 3; id++ {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		addresses[id] = listener.Addr().String()
+		require.NoError(t, listener.Close())
+	}
+	servers := make(map[uint64]*Server)
+	active := make(map[uint64]bool)
+	t.Cleanup(func() {
+		for id := uint64(1); id <= 3; id++ {
+			if active[id] {
+				servers[id].Stop()
+			}
+		}
+	})
+	for id := uint64(1); id <= 3; id++ {
+		cfg := newTestOptions(t, id, addresses, clusterconfig.WithSlotCount(8), clusterconfig.WithSlotMaxReplicaCount(3))
+		s := New(NewOptions(WithAddr("tcp://"+addresses[id]), WithConfigOptions(cfg), WithDataDir(t.TempDir()),
+			WithDBWKDbShardNum(1), WithDBSlotShardNum(1), WithDBWKDbMemTableSize(1<<20), WithDBSlotMemTableSize(1<<20)))
+		require.NoError(t, s.Start())
+		servers[id], active[id] = s, true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for id := uint64(1); id <= 3; id++ {
+		require.NoError(t, servers[id].WaitAllSlotReady(ctx, 8))
+	}
+	var channelID string
+	for i := 0; i < 1000; i++ {
+		candidate := fmt.Sprintf("config-failover-%d", i)
+		if servers[2].cfgServer.SlotLeaderId(servers[2].getSlotId(candidate)) == 2 {
+			channelID = candidate
+			break
+		}
+	}
+	require.NotEmpty(t, channelID)
+	cfg := wkdb.ChannelClusterConfig{ChannelId: channelID, ChannelType: 2, LeaderId: 1, Term: 1,
+		ReplicaMaxCount: 3, Replicas: []uint64{1, 2, 3}, Status: wkdb.ChannelClusterStatusNormal}
+	version, err := servers[2].store.SaveChannelClusterConfig(cfg)
+	require.NoError(t, err)
+	cfg.ConfVersion = version
+	require.NoError(t, servers[1].channelServer.WakeLeaderIfNeed(cfg))
+	appendMessage := func(id int64) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := servers[2].store.AppendMessages(ctx, channelID, 2, []wkdb.Message{{RecvPacket: wkproto.RecvPacket{
+			ChannelID: channelID, ChannelType: 2, MessageID: id, FromUID: "config-failover", Payload: []byte(fmt.Sprintf("message-%d", id)),
+		}}})
+		require.NoError(t, err, "message %d must reach quorum while the old leader remains stopped", id)
+	}
+	for id := int64(1); id <= 3; id++ {
+		appendMessage(id)
+	}
+	require.Eventually(t, func() bool {
+		for _, s := range servers {
+			seq, _, err := s.db.GetChannelLastMessageSeq(channelID, 2)
+			if err != nil || seq != 3 {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, 20*time.Millisecond, "all initial replicas must have the same message tail")
+	servers[1].Stop()
+	active[1] = false
+	require.Eventually(t, func() bool {
+		for _, id := range []uint64{2, 3} {
+			s := servers[id]
+			if s.cfgServer.NodeIsOnline(1) {
+				return false
+			}
+			for _, slot := range s.cfgServer.Slots() {
+				if slot.Leader == 1 {
+					return false
+				}
+			}
+		}
+		return true
+	}, 30*time.Second, 100*time.Millisecond)
+	for id := int64(4); id <= 7; id++ {
+		appendMessage(id)
+	}
+	for _, id := range []uint64{2, 3} {
+		messages, err := servers[id].db.LoadLastMsgs(channelID, 2, 10)
+		require.NoError(t, err)
+		require.Len(t, messages, 7, "both surviving replicas must persist the complete history")
+		for i, message := range messages {
+			require.Equal(t, uint32(i+1), message.MessageSeq)
+			require.Equal(t, int64(i+1), message.MessageID)
+			require.Equal(t, []byte(fmt.Sprintf("message-%d", i+1)), message.Payload)
+		}
+	}
+	// Restart the old leader from its original database. It must rejoin as a
+	// replica of the current leader, catch up, and retain subsequent writes.
+	restartOpts := *servers[1].opts
+	restartOpts.ChannelTransport = nil
+	restartOpts.SlotTransport = nil
+	restarted := New(&restartOpts)
+	require.NoError(t, restarted.Start())
+	servers[1], active[1] = restarted, true
+	require.Eventually(t, func() bool {
+		return servers[2].cfgServer.NodeIsOnline(1) && servers[3].cfgServer.NodeIsOnline(1)
+	}, 20*time.Second, 100*time.Millisecond)
+	appendMessage(8)
+	require.Eventually(t, func() bool {
+		for _, s := range servers {
+			messages, err := s.db.LoadLastMsgs(channelID, 2, 10)
+			if err != nil || len(messages) != 8 {
+				return false
+			}
+			for i, message := range messages {
+				if message.MessageSeq != uint32(i+1) || message.MessageID != int64(i+1) ||
+					string(message.Payload) != fmt.Sprintf("message-%d", i+1) {
+					return false
+				}
+			}
+		}
+		return true
+	}, 10*time.Second, 50*time.Millisecond, "all three replicas must retain the complete history after rejoin")
+}

--- a/pkg/raft/raft/node_config.go
+++ b/pkg/raft/raft/node_config.go
@@ -8,6 +8,24 @@ import (
 	"go.uber.org/zap"
 )
 
+// switchRemoteConfig derives the local role from membership. ConfigResp also
+// carries the sender's role, which older leaders populate with RoleLeader.
+func (n *Node) switchRemoteConfig(cfg types.Config) error {
+	switch {
+	case wkutil.ArrayContainsUint64(cfg.Replicas, n.opts.NodeId):
+		cfg.Role = types.RoleFollower
+		if cfg.Leader == n.opts.NodeId {
+			cfg.Role = types.RoleLeader
+		}
+	case wkutil.ArrayContainsUint64(cfg.Learners, n.opts.NodeId):
+		cfg.Role = types.RoleLearner
+	default:
+		return errors.New("local node is not a member of config response")
+	}
+	cfg.Term = n.cfg.Term
+	return n.switchConfig(cfg)
+}
+
 func (n *Node) switchConfig(newCfg types.Config) error {
 
 	oldCfg := n.cfg

--- a/pkg/raft/raft/node_config_response_test.go
+++ b/pkg/raft/raft/node_config_response_test.go
@@ -1,0 +1,93 @@
+package raft
+
+import (
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigResponseUsesReceiverRole(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		id                 uint64
+		previousRole       types.Role
+		replicas, learners []uint64
+		wantRole           types.Role
+	}{
+		{"follower", 3, types.RoleFollower, []uint64{1, 2, 3}, []uint64{4}, types.RoleFollower},
+		{"learner", 4, types.RoleLearner, []uint64{1, 2, 3}, []uint64{4}, types.RoleLearner},
+		{"promoted learner", 4, types.RoleLearner, []uint64{1, 2, 4}, []uint64{3}, types.RoleFollower},
+		{"demoted follower", 3, types.RoleFollower, []uint64{1, 2, 4}, []uint64{3}, types.RoleLearner},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			leader := newTestNode(2, tc.replicas)
+			require.NoError(t, leader.Step(types.Event{Type: types.ConfChange, Config: types.Config{
+				Replicas: tc.replicas, Learners: tc.learners, Leader: 2, Term: 2, Version: 8, Role: types.RoleLeader,
+			}}))
+			receiver := newTestNode(tc.id, nil)
+			require.NoError(t, receiver.Step(types.Event{Type: types.ConfChange, Config: types.Config{
+				Replicas: []uint64{1, 2, 3}, Learners: []uint64{4}, Leader: 2, Term: 2, Version: 7, Role: tc.previousRole,
+			}}))
+			leader.sendPing(tc.id)
+			for _, e := range collectEvents(leader) {
+				if e.Type == types.Ping {
+					require.NoError(t, receiver.Step(e))
+				}
+			}
+			request, ok := findEvent(collectEvents(receiver), types.ConfigReq)
+			require.True(t, ok, "the newer configuration should trigger a request")
+			require.NoError(t, leader.Step(request))
+			response, ok := findEvent(collectEvents(leader), types.ConfigResp)
+			require.True(t, ok)
+			// Exercise the real leader response, including the legacy sender role.
+			wire, err := response.Marshal()
+			require.NoError(t, err)
+			var decoded types.Event
+			require.NoError(t, decoded.Unmarshal(wire))
+			require.Equal(t, types.RoleLeader, decoded.Config.Role)
+			require.NoError(t, receiver.Step(decoded))
+			require.Equal(t, tc.wantRole, receiver.Config().Role)
+			require.Equal(t, uint64(2), receiver.LeaderId())
+			require.False(t, receiver.IsLeader())
+			// The role must select the correct timer and event handlers, not just
+			// change a field: the replica must still pull and store the next log.
+			for i := 0; i < 30; i++ {
+				receiver.Tick()
+			}
+			sync, ok := findEvent(collectEvents(receiver), types.SyncReq)
+			require.True(t, ok, "replica must continue pulling logs")
+			require.Equal(t, uint64(2), sync.To)
+			require.NoError(t, receiver.Step(types.Event{Type: types.SyncResp, From: 2, To: tc.id, Term: 2,
+				Reason: types.ReasonOk, Logs: []types.Log{{Index: 1, Term: 2, Data: []byte("after-config")}}}))
+			stored, ok := findEvent(collectEvents(receiver), types.StoreReq)
+			require.True(t, ok, "replica must handle the sync response")
+			require.Len(t, stored.Logs, 1)
+			require.Equal(t, []byte("after-config"), stored.Logs[0].Data)
+		})
+	}
+}
+
+func TestConfigResponseRejectsNonmember(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3})
+	makeFollower(n, 2, 2)
+	n.cfg.Version = 7
+	previous := n.Config().Clone()
+	err := n.Step(types.Event{Type: types.ConfigResp, From: 2, Term: 2, Config: types.Config{
+		Replicas: []uint64{2, 3, 4}, Leader: 2, Term: 2, Version: 8, Role: types.RoleLeader,
+	}})
+	require.Error(t, err)
+	require.Equal(t, previous, n.Config().Clone(), "an unrelated response must not assign a local role")
+}
+
+func TestConfigResponseRejectsOlderVersion(t *testing.T) {
+	n := newTestNode(1, []uint64{1, 2, 3})
+	makeFollower(n, 2, 2)
+	n.cfg.Version = 8
+	previous := n.Config().Clone()
+	err := n.Step(types.Event{Type: types.ConfigResp, From: 2, Term: 2, Config: types.Config{
+		Replicas: []uint64{2, 3}, Learners: []uint64{1}, Leader: 2, Term: 2, Version: 7, Role: types.RoleLeader,
+	}})
+	require.Error(t, err)
+	require.Equal(t, previous, n.Config().Clone())
+}

--- a/pkg/raft/raft/node_step.go
+++ b/pkg/raft/raft/node_step.go
@@ -286,9 +286,7 @@ func (n *Node) stepFollower(e types.Event) error {
 		}
 
 	case types.ConfigResp: // 配置返回
-		// 切换配置
-		e.Config.Term = n.cfg.Term
-		n.switchConfig(e.Config)
+		return n.switchRemoteConfig(e.Config)
 
 	}
 	return nil
@@ -387,9 +385,7 @@ func (n *Node) stepLearner(e types.Event) error {
 		}
 
 	case types.ConfigResp: // 配置返回
-		// 切换配置
-		e.Config.Term = n.cfg.Term
-		n.switchConfig(e.Config)
+		return n.switchRemoteConfig(e.Config)
 
 	}
 	return nil


### PR DESCRIPTION
频道 leader 故障切换后，旧版本 `ConfigResp` 会携带发送者的 `RoleLeader`。接收方原样应用这个角色后，follower/learner 会切换到错误的事件和定时处理函数，停止拉取日志；三副本失去一个节点时，这会导致剩余两个节点无法形成多数派提交，消息连续超时。

接收方现在根据本节点 ID 及 `Replicas` / `Learners` 确定本地角色，同时保留配置版本检查并拒绝不包含本节点的响应。处理位于接收端，因此兼容仍发送自身角色的旧节点；不修改线上的编码格式，也不改变本地 `ConfChange` 的处理。

本 PR 独立基于 `fix/raft-orphan-learner-bugs` 的 `d1d484d`，不包含、依赖或修改 PR #40。已在独立工作树将本修复与 PR40 的 `965512c` 叠加，无冲突，相关回归通过。

## 验证

- 新增回归使用真实 leader 生成的 ConfigResp 并经过 Marshal/Unmarshal，覆盖 follower、learner、learner 晋升、follower 降为 learner、非成员及旧版本响应；检查角色、继续发送 SyncReq 和处理后续日志。
- 新增真实 TCP + Pebble 三副本测试：停止旧 leader，检查两份存活副本继续持久化完整消息；再从原数据库重启旧节点，检查三份副本最终消息、序号及顺序一致。`TestChannelReplicationAfterLeaderConfigChange -count=3` 全部通过。
- 基线 overlay 对照：撤去两个生产文件中的修复，相同角色和故障切换回归失败。
- 108 个 Raft 核心测试通过；相关角色/配置回归通过 `-race`；两个变更包的 `go vet` 和服务端构建通过。
- 与 PR40 叠加后，API、cluster、Raft、raftgroup 四个包中选定的 31 个测试通过，包含会话边界读取和本次故障切换回归。

## 全仓测试边界

执行了 `go test ./... -timeout=90s`，全仓仍未通过。基线对照复现了监听端口冲突、消息字符串断言、用户事件测试超时、队列测试和 wkdb 缓存/存储断言失败。本次全仓运行还出现 `TestProposeUntilApplied` 的副本日志断言失败；单独对基线和修复版本运行该测试时，两者均在首轮复现断言失败及随后 panic，因此没有完成指定的 20 次重复。这些失败保留，未通过修改无关测试来消除。

本 PR 不宣称全仓测试全绿，也不将独立三副本回归等同于原浏览器第三轮全部通过；原第三轮单聊的 3 秒 ACK 等待跨越客户端重连窗口，是独立的验证事项。
