### PR TITLE
fix: persist raft term and vote across role changes and restarts

### DIFF
--- a/pkg/cluster/channel/channel.go
+++ b/pkg/cluster/channel/channel.go
@@ -48,6 +48,7 @@ func createChannel(cfg wkdb.ChannelClusterConfig, s *Server, rg *raftgroup.RaftG
 		state,
 		raft.NewOptions(
 			raft.WithKey(channelKey),
+			raft.WithSaveHardState(func(state types.HardState) error { return s.storage.db.SaveRaftHardState(channelKey, state) }),
 			raft.WithAutoSuspend(true),
 			raft.WithAutoDestory(true),
 			raft.WithNodeId(s.opts.NodeId),

--- a/pkg/cluster/channel/hard_state_test.go
+++ b/pkg/cluster/channel/hard_state_test.go
@@ -1,0 +1,72 @@
+package channel
+
+import (
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/raft"
+	"github.com/WuKongIM/WuKongIM/pkg/raft/types"
+	"github.com/WuKongIM/WuKongIM/pkg/wkdb"
+	"github.com/WuKongIM/WuKongIM/pkg/wkutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDurableVoteSurvivesStorageReopen(t *testing.T) {
+	dir := t.TempDir()
+	db := wkdb.NewWukongDB(wkdb.NewOptions(wkdb.WithDir(dir), wkdb.WithShardNum(2)))
+	require.NoError(t, db.Open())
+	s := newStorage(db, nil)
+	state, err := s.GetState("channel", 2)
+	require.NoError(t, err)
+	require.Equal(t, types.HardState{}, state.HardState)
+	n := raft.NewNode(0, state, raft.NewOptions(raft.WithNodeId(1), raft.WithReplicas([]uint64{1, 2, 3}), raft.WithSaveHardState(func(h types.HardState) error { return db.SaveRaftHardState(wkutil.ChannelToKey("channel", 2), h) })))
+	vote := types.Event{Type: types.VoteReq, From: 2, Term: 7, Logs: []types.Log{{Term: 0}}}
+	require.NoError(t, n.Step(vote))
+	events := n.Ready()
+	require.Len(t, events, 1)
+	require.Equal(t, types.ReasonOk, events[0].Reason)
+	require.NoError(t, db.Close())
+	db = wkdb.NewWukongDB(wkdb.NewOptions(wkdb.WithDir(dir), wkdb.WithShardNum(2)))
+	require.NoError(t, db.Open())
+	s = newStorage(db, nil)
+	defer func() { require.NoError(t, db.Close()) }()
+	state, err = s.GetState("channel", 2)
+	require.NoError(t, err)
+	require.Equal(t, types.HardState{Term: 7, Vote: 2}, state.HardState)
+	require.Zero(t, state.LastTerm, "elections without log appends must survive restart")
+	n = raft.NewNode(0, state, raft.NewOptions(raft.WithNodeId(1), raft.WithReplicas([]uint64{1, 2, 3}), raft.WithSaveHardState(func(h types.HardState) error { return db.SaveRaftHardState(wkutil.ChannelToKey("channel", 2), h) })))
+	vote.From = 3
+	require.NoError(t, n.Step(vote))
+	events = n.Ready()
+	require.Len(t, events, 1)
+	require.Equal(t, types.ReasonError, events[0].Reason)
+	vote.Term++
+	require.NoError(t, n.Step(vote))
+	events = n.Ready()
+	require.Len(t, events, 1)
+	require.Equal(t, types.ReasonOk, events[0].Reason)
+}
+
+func TestCreateChannelRestoresDurableVote(t *testing.T) {
+	db := wkdb.NewWukongDB(wkdb.NewOptions(wkdb.WithDir(t.TempDir()), wkdb.WithShardNum(2)))
+	require.NoError(t, db.Open())
+	defer db.Close()
+	s := &Server{opts: NewOptions(WithNodeId(1))}
+	s.storage = newStorage(db, s)
+	cfg := wkdb.ChannelClusterConfig{ChannelId: "channel", ChannelType: 2}
+	ch, err := createChannel(cfg, s, nil)
+	require.NoError(t, err)
+	membership := types.Event{Type: types.ConfChange, Config: types.Config{Replicas: []uint64{1, 2, 3}, Role: types.RoleFollower, Term: 7}}
+	require.NoError(t, ch.Step(membership))
+	vote := types.Event{Type: types.VoteReq, From: 2, Term: 7, Logs: []types.Log{{}}}
+	require.NoError(t, ch.Step(vote))
+	require.NotEmpty(t, ch.Ready())
+	// Destroying/reactivating a channel uses the same production constructor as restart.
+	ch, err = createChannel(cfg, s, nil)
+	require.NoError(t, err)
+	require.NoError(t, ch.Step(membership))
+	vote.From = 3
+	require.NoError(t, ch.Step(vote))
+	events := ch.Ready()
+	require.Len(t, events, 1)
+	require.Equal(t, types.ReasonError, events[0].Reason)
+}

--- a/pkg/cluster/channel/storage.go
+++ b/pkg/cluster/channel/storage.go
@@ -24,7 +24,12 @@ func (s *storage) GetState(channelId string, channelType uint8) (types.RaftState
 		return types.RaftState{}, err
 	}
 
+	state, err := s.db.RaftHardState(wkutil.ChannelToKey(channelId, channelType))
+	if err != nil {
+		return types.RaftState{}, err
+	}
 	return types.RaftState{
+		HardState:    state,
 		LastLogIndex: uint64(lastMsg.MessageSeq),
 		LastTerm:     uint32(lastMsg.Term),
 		AppliedIndex: uint64(lastMsg.MessageSeq),

--- a/pkg/cluster/node/clusterconfig/hard_state_test.go
+++ b/pkg/cluster/node/clusterconfig/hard_state_test.go
@@ -1,0 +1,43 @@
+package clusterconfig
+
+import (
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/raft"
+	"github.com/WuKongIM/WuKongIM/pkg/raft/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDurableVoteSurvivesStorageReopen(t *testing.T) {
+	dir := t.TempDir()
+	s := NewPebbleShardLogStorage(dir, nil)
+	require.NoError(t, s.Open())
+	state, err := s.GetState()
+	require.NoError(t, err)
+	require.Equal(t, types.HardState{}, state.HardState)
+	n := raft.NewNode(0, state, raft.NewOptions(raft.WithNodeId(1), raft.WithReplicas([]uint64{1, 2, 3}), raft.WithSaveHardState(s.SaveHardState)))
+	vote := types.Event{Type: types.VoteReq, From: 2, Term: 7, Logs: []types.Log{{Term: 0}}}
+	require.NoError(t, n.Step(vote))
+	events := n.Ready()
+	require.Len(t, events, 1)
+	require.Equal(t, types.ReasonOk, events[0].Reason)
+	require.NoError(t, s.Close())
+	s = NewPebbleShardLogStorage(dir, nil)
+	require.NoError(t, s.Open())
+	defer func() { require.NoError(t, s.Close()) }()
+	state, err = s.GetState()
+	require.NoError(t, err)
+	require.Equal(t, types.HardState{Term: 7, Vote: 2}, state.HardState)
+	require.Zero(t, state.LastTerm, "elections without log appends must survive restart")
+	n = raft.NewNode(0, state, raft.NewOptions(raft.WithNodeId(1), raft.WithReplicas([]uint64{1, 2, 3}), raft.WithSaveHardState(s.SaveHardState)))
+	vote.From = 3
+	require.NoError(t, n.Step(vote))
+	events = n.Ready()
+	require.Len(t, events, 1)
+	require.Equal(t, types.ReasonError, events[0].Reason)
+	vote.Term++
+	require.NoError(t, n.Step(vote))
+	events = n.Ready()
+	require.Len(t, events, 1)
+	require.Equal(t, types.ReasonOk, events[0].Reason)
+}

--- a/pkg/cluster/node/clusterconfig/key/key.go
+++ b/pkg/cluster/node/clusterconfig/key/key.go
@@ -59,3 +59,5 @@ func NewAppliedIndexKey() []byte {
 	key[3] = 0
 	return key
 }
+
+func NewHardStateKey() []byte { return []byte{0x5, 0x5, 0, 0} }

--- a/pkg/cluster/node/clusterconfig/storage.go
+++ b/pkg/cluster/node/clusterconfig/storage.go
@@ -174,7 +174,13 @@ func (p *PebbleShardLogStorage) GetState() (types.RaftState, error) {
 		return types.RaftState{}, err
 	}
 
+	state, err := p.hardState()
+	if err != nil {
+		return types.RaftState{}, err
+	}
+
 	return types.RaftState{
+		HardState:    state,
 		LastLogIndex: lastIndex,
 		LastTerm:     lastTerm,
 		AppliedIndex: applied,
@@ -475,4 +481,22 @@ func (p *PebbleShardLogStorage) saveMaxIndexWithWriter(index uint64, w pebble.Wr
 
 	err := w.Set(maxIndexKeyData, append(maxIndexdata, lastTimeData...), o)
 	return err
+}
+
+func (p *PebbleShardLogStorage) SaveHardState(state types.HardState) error {
+	return p.db.Set(key.NewHardStateKey(), state.Marshal(), pebble.Sync)
+}
+
+func (p *PebbleShardLogStorage) hardState() (types.HardState, error) {
+	var state types.HardState
+	data, closer, err := p.db.Get(key.NewHardStateKey())
+	if errors.Is(err, pebble.ErrNotFound) {
+		return state, nil
+	}
+	if err != nil {
+		return state, err
+	}
+	defer closer.Close()
+	err = state.Unmarshal(data)
+	return state, err
 }

--- a/pkg/cluster/slot/hard_state_test.go
+++ b/pkg/cluster/slot/hard_state_test.go
@@ -1,0 +1,43 @@
+package slot
+
+import (
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/raft"
+	"github.com/WuKongIM/WuKongIM/pkg/raft/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDurableVoteSurvivesStorageReopen(t *testing.T) {
+	dir := t.TempDir()
+	s := NewPebbleShardLogStorage(nil, dir, 2)
+	require.NoError(t, s.Open())
+	state, err := s.GetState("slot-1")
+	require.NoError(t, err)
+	require.Equal(t, types.HardState{}, state.HardState)
+	n := raft.NewNode(0, state, raft.NewOptions(raft.WithNodeId(1), raft.WithReplicas([]uint64{1, 2, 3}), raft.WithSaveHardState(func(h types.HardState) error { return s.SaveHardState("slot-1", h) })))
+	vote := types.Event{Type: types.VoteReq, From: 2, Term: 7, Logs: []types.Log{{Term: 0}}}
+	require.NoError(t, n.Step(vote))
+	events := n.Ready()
+	require.Len(t, events, 1)
+	require.Equal(t, types.ReasonOk, events[0].Reason)
+	require.NoError(t, s.Close())
+	s = NewPebbleShardLogStorage(nil, dir, 2)
+	require.NoError(t, s.Open())
+	defer func() { require.NoError(t, s.Close()) }()
+	state, err = s.GetState("slot-1")
+	require.NoError(t, err)
+	require.Equal(t, types.HardState{Term: 7, Vote: 2}, state.HardState)
+	require.Zero(t, state.LastTerm, "elections without log appends must survive restart")
+	n = raft.NewNode(0, state, raft.NewOptions(raft.WithNodeId(1), raft.WithReplicas([]uint64{1, 2, 3}), raft.WithSaveHardState(func(h types.HardState) error { return s.SaveHardState("slot-1", h) })))
+	vote.From = 3
+	require.NoError(t, n.Step(vote))
+	events = n.Ready()
+	require.Len(t, events, 1)
+	require.Equal(t, types.ReasonError, events[0].Reason)
+	vote.Term++
+	require.NoError(t, n.Step(vote))
+	events = n.Ready()
+	require.Len(t, events, 1)
+	require.Equal(t, types.ReasonOk, events[0].Reason)
+}

--- a/pkg/cluster/slot/key/key.go
+++ b/pkg/cluster/slot/key/key.go
@@ -77,3 +77,9 @@ func shardNoToShardID(shardNo string) uint64 {
 	}
 	return h.Sum64()
 }
+
+func NewHardStateKey(shardNo string) []byte {
+	k := NewAppliedIndexKey(shardNo)
+	k[0], k[1] = 0x5, 0x5
+	return k
+}

--- a/pkg/cluster/slot/slot.go
+++ b/pkg/cluster/slot/slot.go
@@ -3,6 +3,7 @@ package slot
 import (
 	"github.com/WuKongIM/WuKongIM/pkg/cluster/node/types"
 	"github.com/WuKongIM/WuKongIM/pkg/raft/raft"
+	rafttypes "github.com/WuKongIM/WuKongIM/pkg/raft/types"
 	"github.com/WuKongIM/WuKongIM/pkg/wklog"
 	"go.uber.org/zap"
 )
@@ -29,7 +30,7 @@ func newSlot(slot *types.Slot, s *Server) *Slot {
 	if err != nil {
 		st.Panic("get last term failed", zap.Error(err))
 	}
-	node := raft.NewNode(lastLogIndex, state, raft.NewOptions(raft.WithKey(shardNo), raft.WithNodeId(s.opts.NodeId)))
+	node := raft.NewNode(lastLogIndex, state, raft.NewOptions(raft.WithKey(shardNo), raft.WithNodeId(s.opts.NodeId), raft.WithSaveHardState(func(state rafttypes.HardState) error { return s.storage.SaveHardState(shardNo, state) })))
 	st.Node = node
 
 	return st

--- a/pkg/cluster/slot/storage_pebble.go
+++ b/pkg/cluster/slot/storage_pebble.go
@@ -180,7 +180,13 @@ func (p *PebbleShardLogStorage) GetState(shardNo string) (types.RaftState, error
 			zap.Uint64("newAppliedIndex", applied))
 	}
 
+	state, err := p.hardState(shardNo)
+	if err != nil {
+		return types.RaftState{}, err
+	}
+
 	return types.RaftState{
+		HardState:    state,
 		LastLogIndex: lastLogIndex,
 		LastTerm:     lastLogTerm,
 		AppliedIndex: applied,
@@ -756,3 +762,21 @@ func (p *PebbleShardLogStorage) DeleteLeaderTermStartIndexGreaterThanTerm(shardN
 // func (l *localStorage) getChannelSlotId(channelId string) uint32 {
 // 	return wkutil.GetSlotNum(int(l.opts.SlotCount), channelId)
 // }
+
+func (p *PebbleShardLogStorage) SaveHardState(shardNo string, state types.HardState) error {
+	return p.shardDB(shardNo).Set(key.NewHardStateKey(shardNo), state.Marshal(), pebble.Sync)
+}
+
+func (p *PebbleShardLogStorage) hardState(shardNo string) (types.HardState, error) {
+	var state types.HardState
+	data, closer, err := p.shardDB(shardNo).Get(key.NewHardStateKey(shardNo))
+	if errors.Is(err, pebble.ErrNotFound) {
+		return state, nil
+	}
+	if err != nil {
+		return state, err
+	}
+	defer closer.Close()
+	err = state.Unmarshal(data)
+	return state, err
+}

--- a/pkg/raft/raft/node.go
+++ b/pkg/raft/raft/node.go
@@ -12,7 +12,6 @@ import (
 type electionState struct {
 	electionElapsed           int             // 选举计时器
 	randomizedElectionTimeout int             // 随机选举超时时间
-	voteFor                   uint64          // 投票给了谁
 	votes                     map[uint64]bool // 投票记录,key为节点id，value为是否同意
 }
 
@@ -32,10 +31,12 @@ type Node struct {
 	stepFunc    func(event types.Event) error
 	queue       *queue // 日志队列
 	wklog.Log
-	heartbeatElapsed int          // 心跳计时器
-	cfg              types.Config // 分布式配置
-	electionState                 // 选举状态
-	syncState                     // 同步状态
+	heartbeatElapsed   int          // 心跳计时器
+	cfg                types.Config // 分布式配置
+	voteFor            uint64       // 本任期的投票，不随角色重置
+	persistedHardState types.HardState
+	electionState      // 选举状态
+	syncState          // 同步状态
 	// 最新的任期对应的开始日志下标
 	lastTermStartIndex types.TermStartIndexInfo
 	onlySync           bool // 是否只同步,不做截断判断
@@ -69,6 +70,11 @@ func NewNode(lastTermStartLogIndex uint64, raftState types.RaftState, opts *Opti
 	} else {
 		n.cfg.Term = raftState.LastTerm
 	}
+	if raftState.HardState.Term >= n.cfg.Term {
+		n.cfg.Term = raftState.HardState.Term
+		n.voteFor = raftState.HardState.Vote
+	}
+	n.persistedHardState = raftState.HardState
 	// 初始化日志队列
 	n.queue = newQueue(opts.Key, raftState.AppliedIndex, raftState.LastLogIndex)
 
@@ -78,7 +84,7 @@ func NewNode(lastTermStartLogIndex uint64, raftState types.RaftState, opts *Opti
 	n.resetRandomizedElectionTimeout()
 
 	n.lastTermStartIndex.Index = lastTermStartLogIndex
-	n.lastTermStartIndex.Term = n.cfg.Term
+	n.lastTermStartIndex.Term = raftState.LastTerm
 
 	onlySelf := false
 	if len(n.cfg.Replicas) == 1 {
@@ -122,6 +128,9 @@ func (n *Node) LastTerm() uint32 {
 
 // HasReady 是否有待处理的事件
 func (n *Node) HasReady() bool {
+	if n.hasUnpersistedHardState() {
+		return true
+	}
 	if n.queue.hasNextStoreLogs() {
 		return true
 	}
@@ -138,6 +147,17 @@ func (n *Node) Suspend() bool {
 
 // Ready 获取待处理的事件
 func (n *Node) Ready() []types.Event {
+	// Persist before releasing ANY event, including self-votes and log writes.
+	// On failure retain the events and retry on the next tick. No vote response
+	// or leader read may escape with an unrecorded term/vote.
+	if n.hasUnpersistedHardState() {
+		state := n.hardState()
+		if err := n.opts.SaveHardState(state); err != nil {
+			n.Error("persist raft hard state failed", zap.Error(err))
+			return nil
+		}
+		n.persistedHardState = state
+	}
 
 	if n.queue.hasNextStoreLogs() {
 		logs := n.queue.nextStoreLogs(0)

--- a/pkg/raft/raft/node_become.go
+++ b/pkg/raft/raft/node_become.go
@@ -9,7 +9,7 @@ func (n *Node) BecomeCandidate() {
 	if n.cfg.Role == types.RoleLeader {
 		n.Panic("invalid transition [leader -> candidate]")
 	}
-	n.cfg.Term++
+	n.setTerm(n.cfg.Term + 1)
 	n.stepFunc = n.stepCandidate
 	n.reset()
 	n.tickFnc = n.tickCandidate
@@ -20,11 +20,13 @@ func (n *Node) BecomeCandidate() {
 }
 
 func (n *Node) BecomeFollower(term uint32, leaderId uint64) {
-	n.cfg.Term = term
+	if term < n.cfg.Term {
+		return
+	}
+	n.setTerm(term)
 	n.stepFunc = n.stepFollower
 	n.reset()
 	n.tickFnc = n.tickFollower
-	n.voteFor = None
 	n.cfg.Leader = leaderId
 	n.cfg.Role = types.RoleFollower
 
@@ -37,7 +39,10 @@ func (n *Node) BecomeFollower(term uint32, leaderId uint64) {
 }
 
 func (n *Node) BecomeLeader(term uint32) {
-	n.cfg.Term = term
+	if term < n.cfg.Term {
+		return
+	}
+	n.setTerm(term)
 	n.stepFunc = n.stepLeader
 	n.reset()
 	n.tickFnc = n.tickLeader
@@ -53,11 +58,13 @@ func (n *Node) BecomeLeader(term uint32) {
 }
 
 func (n *Node) BecomeLearner(term uint32, leaderId uint64) {
-	n.cfg.Term = term
+	if term < n.cfg.Term {
+		return
+	}
+	n.setTerm(term)
 	n.stepFunc = n.stepLearner
 	n.reset()
 	n.tickFnc = n.tickLearner
-	n.voteFor = None
 	n.cfg.Leader = leaderId
 	n.cfg.Role = types.RoleLearner
 

--- a/pkg/raft/raft/node_become_test.go
+++ b/pkg/raft/raft/node_become_test.go
@@ -51,7 +51,7 @@ func TestBecomeLearner_SetsState(t *testing.T) {
 	assert.NotNil(t, n.tickFnc)
 }
 
-func TestReset_ClearsState(t *testing.T) {
+func TestReset_ClearsVolatileState(t *testing.T) {
 	n := newTestNode(1, []uint64{1, 2, 3})
 	n.voteFor = 2
 	n.votes[2] = true
@@ -60,7 +60,7 @@ func TestReset_ClearsState(t *testing.T) {
 	n.suspend = true
 	n.replicaSync[2] = &SyncInfo{StoredIndex: 10}
 	n.reset()
-	assert.Equal(t, uint64(0), n.voteFor)
+	assert.Equal(t, uint64(2), n.voteFor)
 	assert.Equal(t, 0, len(n.votes))
 	assert.False(t, n.stopPropose)
 	assert.False(t, n.onlySync)

--- a/pkg/raft/raft/node_config.go
+++ b/pkg/raft/raft/node_config.go
@@ -30,6 +30,7 @@ func (n *Node) switchConfig(newCfg types.Config) error {
 	n.resetRandomizedElectionTimeout()
 
 	// 比较角色是否发生变化
+	n.setTerm(newCfg.Term)
 	n.roleChangeIfNeed(oldCfg, newCfg)
 
 	n.cfg = newCfg

--- a/pkg/raft/raft/node_hard_state.go
+++ b/pkg/raft/raft/node_hard_state.go
@@ -1,0 +1,18 @@
+package raft
+
+import "github.com/WuKongIM/WuKongIM/pkg/raft/types"
+
+func (n *Node) setTerm(term uint32) {
+	if term > n.cfg.Term {
+		n.voteFor = None
+		n.cfg.Term = term
+	}
+}
+
+func (n *Node) hardState() types.HardState {
+	return types.HardState{Term: n.cfg.Term, Vote: n.voteFor}
+}
+
+func (n *Node) hasUnpersistedHardState() bool {
+	return n.opts.SaveHardState != nil && n.hardState() != n.persistedHardState
+}

--- a/pkg/raft/raft/node_hard_state_test.go
+++ b/pkg/raft/raft/node_hard_state_test.go
@@ -1,0 +1,112 @@
+package raft
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/types"
+	"github.com/stretchr/testify/require"
+)
+
+func voteRequest(from uint64, term uint32) types.Event {
+	return types.Event{Type: types.VoteReq, From: from, Term: term, Logs: []types.Log{{Term: 1}}}
+}
+
+func TestVoteSurvivesSameTermTransitions(t *testing.T) {
+	transitions := map[string]func(*Node){
+		"follower":         func(n *Node) { n.BecomeFollower(3, 2) },
+		"leader":           func(n *Node) { n.BecomeLeader(3) },
+		"learner and back": func(n *Node) { n.BecomeLearner(3, 2); n.BecomeFollower(3, 2) },
+		"first heartbeat":  func(n *Node) { require.NoError(t, n.Step(types.Event{Type: types.Ping, From: 2, Term: 3})) },
+		"configuration": func(n *Node) {
+			cfg := n.cfg.Clone()
+			cfg.Version++
+			cfg.Leader = 2
+			require.NoError(t, n.switchConfig(cfg))
+		},
+	}
+	for name, transition := range transitions {
+		t.Run(name, func(t *testing.T) {
+			n := newTestNode(1, []uint64{1, 2, 3})
+			require.NoError(t, n.Step(voteRequest(2, 3)))
+			first, ok := findEvent(n.Ready(), types.VoteResp)
+			require.True(t, ok)
+			require.Equal(t, types.ReasonOk, first.Reason)
+			transition(n)
+			retry := voteRequest(3, 3)
+			retry.ConfigVersion = n.cfg.Version
+			require.NoError(t, n.Step(retry))
+			second, ok := findEvent(n.Ready(), types.VoteResp)
+			require.True(t, ok)
+			require.Equal(t, types.ReasonError, second.Reason)
+			retry.Term = 4
+			require.NoError(t, n.Step(retry))
+			next, ok := findEvent(n.Ready(), types.VoteResp)
+			require.True(t, ok)
+			require.Equal(t, types.ReasonOk, next.Reason)
+		})
+	}
+}
+
+func TestHardStateBlocksEventsUntilDurable(t *testing.T) {
+	for _, campaign := range []bool{false, true} {
+		t.Run(map[bool]string{false: "grant", true: "campaign"}[campaign], func(t *testing.T) {
+			var saved types.HardState
+			fail := true
+			n := NewNode(0, types.RaftState{}, NewOptions(WithNodeId(1), WithReplicas([]uint64{1, 2, 3}), WithSaveHardState(func(s types.HardState) error {
+				if fail {
+					return errors.New("disk unavailable")
+				}
+				saved = s
+				return nil
+			})))
+			if campaign {
+				n.campaign()
+			} else {
+				require.NoError(t, n.Step(voteRequest(2, 3)))
+			}
+			require.Empty(t, n.Ready(), "no election message may escape a failed write")
+			require.True(t, n.HasReady(), "failed writes must remain retryable")
+			require.Zero(t, saved.Term)
+			fail = false
+			events := n.Ready()
+			require.NotEmpty(t, events)
+			require.Equal(t, n.cfg.Term, saved.Term)
+			require.Equal(t, n.voteFor, saved.Vote)
+			restarted := NewNode(0, types.RaftState{HardState: saved}, NewOptions(WithNodeId(1), WithReplicas([]uint64{1, 2, 3})))
+			require.NoError(t, restarted.Step(voteRequest(3, saved.Term)))
+			resp, ok := findEvent(restarted.Ready(), types.VoteResp)
+			require.True(t, ok)
+			require.Equal(t, types.ReasonError, resp.Reason)
+		})
+	}
+}
+
+func TestHardStateRestoresTermIndependentlyOfLogTerm(t *testing.T) {
+	n := NewNode(1, types.RaftState{LastLogIndex: 2, LastTerm: 3, AppliedIndex: 2, HardState: types.HardState{Term: 9, Vote: 2}}, NewOptions(WithNodeId(1), WithReplicas([]uint64{1, 2, 3})))
+	require.Equal(t, uint32(9), n.LastTerm())
+	require.Equal(t, uint32(3), n.LastLogTerm())
+	n.BecomeFollower(8, 3)
+	require.Equal(t, uint32(9), n.LastTerm())
+	require.Equal(t, uint64(2), n.voteFor)
+	require.NoError(t, n.Step(types.Event{Type: types.Ping, From: 3, Term: 8}))
+	require.Equal(t, uint64(2), n.voteFor)
+	n.BecomeFollower(10, 3)
+	require.Zero(t, n.voteFor)
+}
+
+func TestLeaderReadWaitsForDurableTerm(t *testing.T) {
+	fail := true
+	n := NewNode(0, types.RaftState{}, NewOptions(WithNodeId(1), WithReplicas([]uint64{1}), WithSaveHardState(func(types.HardState) error {
+		if fail {
+			return errors.New("disk unavailable")
+		}
+		return nil
+	})))
+	require.False(t, n.LeaderReadReady())
+	require.Empty(t, n.Ready())
+	require.False(t, n.LeaderReadReady())
+	fail = false
+	n.Ready()
+	require.True(t, n.LeaderReadReady())
+}

--- a/pkg/raft/raft/node_read.go
+++ b/pkg/raft/raft/node_read.go
@@ -3,5 +3,5 @@ package raft
 // LeaderReadReady must be called on the owner's event loop, just like Step.
 // A leader draining proposals for transfer must not certify a read boundary.
 func (n *Node) LeaderReadReady() bool {
-	return n.IsLeader() && !n.stopPropose && !n.truncating
+	return n.IsLeader() && !n.hasUnpersistedHardState() && !n.stopPropose && !n.truncating
 }

--- a/pkg/raft/raft/node_step.go
+++ b/pkg/raft/raft/node_step.go
@@ -42,13 +42,13 @@ func (n *Node) Step(e types.Event) error {
 	case types.VoteReq: // 投票请求
 		if n.cfg.Role != types.RoleLearner {
 			if n.canVote(e) {
+				n.voteFor = e.From
 				if e.From == n.opts.NodeId {
 					n.sendVoteResp(types.LocalNode, types.ReasonOk)
 				} else {
 					n.sendVoteResp(e.From, types.ReasonOk)
 				}
 
-				n.voteFor = e.From
 				n.electionElapsed = 0
 				if e.From != n.opts.NodeId {
 					n.Info("agree vote", zap.Uint64("voteFor", e.From), zap.Uint32("term", e.Term), zap.Uint64("index", e.Index))

--- a/pkg/raft/raft/options.go
+++ b/pkg/raft/raft/options.go
@@ -2,6 +2,8 @@ package raft
 
 import (
 	"time"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/types"
 )
 
 type Options struct {
@@ -29,6 +31,9 @@ type Options struct {
 	Transport Transport
 	//	 Storage 存储层
 	Storage Storage
+	// SaveHardState synchronously persists term/vote. Required for durable Node embedders.
+	// Raft.New supplies this from Storage; nil is for in-memory state-machine users.
+	SaveHardState func(types.HardState) error
 	// Advance 用于推进状态机
 	Advance func()
 	// MaxLogCountPerBatch 每次同步的最大日志数量
@@ -215,4 +220,8 @@ func WithAutoDestory(autoDestory bool) Option {
 	return func(opts *Options) {
 		opts.AutoDestory = autoDestory
 	}
+}
+
+func WithSaveHardState(save func(types.HardState) error) Option {
+	return func(opts *Options) { opts.SaveHardState = save }
 }

--- a/pkg/raft/raft/raft.go
+++ b/pkg/raft/raft/raft.go
@@ -35,6 +35,7 @@ type Raft struct {
 }
 
 func New(opts *Options) *Raft {
+	opts.SaveHardState = opts.Storage.SaveHardState
 
 	raftState, err := opts.Storage.GetState()
 	if err != nil {

--- a/pkg/raft/raft/raft_test.go
+++ b/pkg/raft/raft/raft_test.go
@@ -353,6 +353,7 @@ func (t *testTransport) Send(event types.Event) {
 }
 
 type testStorage struct {
+	hardState       types.HardState
 	nodeId          uint64
 	logs            []types.Log
 	termStartIndexs []*types.TermStartIndexInfo
@@ -382,10 +383,11 @@ func (s *testStorage) GetLogs(start, end uint64, limitSize uint64) ([]types.Log,
 
 func (s *testStorage) GetState() (types.RaftState, error) {
 	if len(s.logs) == 0 {
-		return types.RaftState{}, nil
+		return types.RaftState{HardState: s.hardState}, nil
 	}
 	lastLog := s.logs[len(s.logs)-1]
 	return types.RaftState{
+		HardState:    s.hardState,
 		LastLogIndex: lastLog.Index,
 		LastTerm:     lastLog.Term,
 		AppliedIndex: lastLog.Index,
@@ -533,3 +535,5 @@ func raftStop(rafts ...*raft.Raft) {
 		r.Stop()
 	}
 }
+
+func (s *testStorage) SaveHardState(state types.HardState) error { s.hardState = state; return nil }

--- a/pkg/raft/raft/storage.go
+++ b/pkg/raft/raft/storage.go
@@ -3,6 +3,8 @@ package raft
 import "github.com/WuKongIM/WuKongIM/pkg/raft/types"
 
 type Storage interface {
+	// SaveHardState must durably save term and vote together before returning.
+	SaveHardState(types.HardState) error
 	// AppendLogs 追加日志, 如果termStartIndex不为nil, 则需要保存termStartIndex，最好确保原子性
 	AppendLogs(logs []types.Log, termStartIndex *types.TermStartIndexInfo) error
 	// GetLogs 获取日志 startLogIndex日志开始下标,endLogIndex结束日志下标 limitSize限制每次查询日志大小，0表示不限制，结果包含startLogIndex不包含 endLogIndex

--- a/pkg/raft/types/hard_state.go
+++ b/pkg/raft/types/hard_state.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// HardState is local election state, independent of the last log's term.
+// Its two fields must be persisted atomically and survive log truncation.
+type HardState struct {
+	Term uint32
+	Vote uint64
+}
+
+func (s HardState) Marshal() []byte {
+	data := make([]byte, 12)
+	binary.BigEndian.PutUint32(data, s.Term)
+	binary.BigEndian.PutUint64(data[4:], s.Vote)
+	return data
+}
+
+func (s *HardState) Unmarshal(data []byte) error {
+	if len(data) != 12 {
+		return fmt.Errorf("invalid raft hard state length: %d", len(data))
+	}
+	s.Term = binary.BigEndian.Uint32(data)
+	s.Vote = binary.BigEndian.Uint64(data[4:])
+	if s.Term == 0 && s.Vote != 0 {
+		return fmt.Errorf("raft vote without a term")
+	}
+	return nil
+}

--- a/pkg/raft/types/hard_state_test.go
+++ b/pkg/raft/types/hard_state_test.go
@@ -1,0 +1,13 @@
+package types
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestHardStateRejectsCorruptRecord(t *testing.T) {
+	for _, data := range [][]byte{nil, make([]byte, 11), make([]byte, 13), HardState{Vote: 2}.Marshal()} {
+		var state HardState
+		require.Error(t, state.Unmarshal(data))
+	}
+}

--- a/pkg/raft/types/types.go
+++ b/pkg/raft/types/types.go
@@ -749,6 +749,7 @@ func (t *TermStartIndexInfo) Clone() *TermStartIndexInfo {
 const LocalNode = math.MaxUint64
 
 type RaftState struct {
+	HardState HardState
 	// LastLogIndex 最后一个日志的下标
 	LastLogIndex uint64
 	// LastTerm 最后一个日志的任期

--- a/pkg/wkdb/db.go
+++ b/pkg/wkdb/db.go
@@ -1,6 +1,10 @@
 package wkdb
 
+import "github.com/WuKongIM/WuKongIM/pkg/raft/types"
+
 type DB interface {
+	SaveRaftHardState(shardNo string, state types.HardState) error
+	RaftHardState(shardNo string) (types.HardState, error)
 	Open() error
 	Close() error
 	// 获取下一个主键

--- a/pkg/wkdb/key/key.go
+++ b/pkg/wkdb/key/key.go
@@ -1165,3 +1165,8 @@ func NewMessageEventSeqKey(channelId string, channelType uint8, clientMsgNo stri
 	binary.BigEndian.PutUint64(key[12:], HashWithString(clientMsgNo))
 	return key
 }
+
+// NewRaftHardStateKey uses a dedicated table and the full shard identity.
+func NewRaftHardStateKey(shardNo string) []byte {
+	return append([]byte{0x1B, 0x01, dataTypeOther, 0}, []byte(shardNo)...)
+}

--- a/pkg/wkdb/raft_hard_state.go
+++ b/pkg/wkdb/raft_hard_state.go
@@ -1,0 +1,27 @@
+package wkdb
+
+import (
+	"errors"
+
+	"github.com/WuKongIM/WuKongIM/pkg/raft/types"
+	"github.com/WuKongIM/WuKongIM/pkg/wkdb/key"
+	"github.com/cockroachdb/pebble"
+)
+
+func (wk *wukongDB) SaveRaftHardState(shardNo string, state types.HardState) error {
+	return wk.shardDB(shardNo).Set(key.NewRaftHardStateKey(shardNo), state.Marshal(), pebble.Sync)
+}
+
+func (wk *wukongDB) RaftHardState(shardNo string) (types.HardState, error) {
+	var state types.HardState
+	data, closer, err := wk.shardDB(shardNo).Get(key.NewRaftHardStateKey(shardNo))
+	if errors.Is(err, pebble.ErrNotFound) {
+		return state, nil
+	}
+	if err != nil {
+		return state, err
+	}
+	defer closer.Close()
+	err = state.Unmarshal(data)
+	return state, err
+}


### PR DESCRIPTION
同任期角色切换和首个心跳会清空 `voteFor`，节点重启后也没有可恢复的任期/投票记录，可能再次给另一候选人投票。本 PR 将投票记录与选举计时、收票状态分离，仅在任期增加时清空，并增加持久化恢复。

- 配置、槽、频道三种 Raft 存储均保存原子的 `term + vote`；恢复时区分当前任期与最后一条日志任期。
- `Ready()` 在释放选举消息、日志事件前同步保存状态；保存失败保留事件等待重试，Leader 读也不越过持久化屏障。
- 覆盖角色切换、首个心跳、自投票、写入失败、无新日志时重启、三种实际存储重开及频道重新激活。

验证：Raft/raftgroup、配置、槽、频道相关包通过；新增专项 `-race` 检查通过。与成员资格修复 #43 及 #41 组合后，相关包 `-count=3`、专项 `-race`、`TestChannelReplicationAfterLeaderConfigChange` 均通过。

已执行全仓 `go test -p 1 ./... -count=1 -timeout 60s`（独立网络命名空间）。结果未全绿：原始 `1187497` 同样存在 server、track、user/event、cluster、wkdb、wknet、wkserver 测试失败/超时；本轮全量运行另记录 wkserver/test 超时，同条件单包复查时基线和本分支均通过，超时原因未进一步定位。不能将专项通过描述为全仓通过，完整业务五轮尚未重跑。

持久化为新增本地元数据，不改变网络消息格式。旧版本未记录的历史投票无法追溯恢复；完整 P0 修复仍需配套成员资格修复 #43 和 #41。本 PR 不包含 P1 消息幂等或在线连接迁移。
